### PR TITLE
Fix typos.

### DIFF
--- a/Changes/index.php
+++ b/Changes/index.php
@@ -369,7 +369,7 @@
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/DrowLineage.png" align="middle"> Drow Lineage</p></b>
 <p><b>Old Effect</b>: Increase offline production bonus by a multiplicative 75% for every level.</p>
 <p><b>New Effect</b>: Increase offline production bonus based on Lineage level. Does not suffer from Ascension penalties.</p>
-<p><b>Formula</b>: (150 * L ^ 2.25), where x is Lineage level.</p>
+<p><b>Formula</b>: (150 * L ^ 2.25), where L is Lineage level.</p>
 <br/>
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk3.png" align="middle"> Drow Perk 3</p></b>
 <p><b>Old Effect</b>: Increase offline production by 10.0% for every 500 Unique Building.</p>

--- a/Lineages/index.php
+++ b/Lineages/index.php
@@ -489,7 +489,7 @@
     <p><b>Cost</b>: 400 Drow Royal Exchanges.</p>
     <p><b>Effect</b>: Increase offline production bonus based on Lineage level.
     <p><b>Note</b>: Does not suffer from Ascension penalties.</p>
-    <p><b>Formula</b>: (150 * L ^ 2.25), where x is Lineage level.</p>
+    <p><b>Formula</b>: (150 * L ^ 2.25), where L is Lineage level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk1.png" align="middle"><b> Drow Perk 1</b></p>

--- a/R111-R115/index.php
+++ b/R111-R115/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated Jan 12th 2019</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982031-row"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982031-row"><b>megathread</b></a>  forum page</p>
     <p><b>Note</b>: All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page
 <br/>
 <div class="shlisting">

--- a/R116Plus/index.php
+++ b/R116Plus/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated Feb 21st, 2019</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982032-row"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982032-row"><b>megathread</b></a>  forum page</p>
     <p><b>Note</b>: All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page
 <br/>
 <div class="shlisting">

--- a/R125Plus/index.php
+++ b/R125Plus/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated Feb 21st, 2019</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982033-row"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982033-row"><b>megathread</b></a>  forum page</p>
 <br/>
 <div class="shlisting">
     <p><b>Production Builds</b></p>

--- a/R40-R46/index.php
+++ b/R40-R46/index.php
@@ -9,7 +9,7 @@
     <br/>
     <p><b>Updated Nov. 28th 2017</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
     <p>All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page</p>
 <br/>
         <p><b>Note</b>: It is recommended to get at least 1 No (1e30) gems before starting stage 3 of Dragon Unlocks.</p>

--- a/R47-R60/index.php
+++ b/R47-R60/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated Nov. 28th 2017</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
     <p><b>Note</b>: All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page
 <br/>
 <br/>

--- a/R75Plus/index.php
+++ b/R75Plus/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated June 20th 2018</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
     <p><b>Note</b>: All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page
 <br/>
 <br/>

--- a/R90Plus/index.php
+++ b/R90Plus/index.php
@@ -9,7 +9,7 @@
 <br/>
     <p><b>Updated Jan 12th 2019</b>
       <p><FONT color=DarkRed>No builds have been updated for the 3.5 patch and may or may not work, check <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder"><b>RG forum</b></a> on kongregate for newer builds, once builds have been tested and added to NaW this line will be removed.</font><p>
-    <p>All builds comes from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982027-row"><b>megathread</b></a>  forum page</p>
+    <p>All builds come from the  <a target="_blank" href="https://www.kongregate.com/forums/8945-realm-grinder/topics/1787989#posts-12982027-row"><b>megathread</b></a>  forum page</p>
     <p>All Obsolete builds moved to  <b><a target="_blank" href="http://musicfamily.org/realm/Obsolete/">Obsolete</b></a> page
 <br/>
 <br/>

--- a/SpecialBuilds/index.php
+++ b/SpecialBuilds/index.php
@@ -7,7 +7,7 @@
 <h6><img src="http://musicfamily.org/realm/Factions/picks/TrophyTopPage.png" alt="Spellcraft" align="middle"></h6>
 <br/>
 <p><b>Updated Oct. 26th 2017</b>
-<p>All builds comes from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
+<p>All builds come from the  <a target="_blank" href="http://www.kongregate.com/forums/8945-realm-grinder/topics/922600-3-0-build-megathread-under-construction-please-post-builds-to-add?page=1"><b>megathread</b></a>  forum page</p>
 <br/>
 <p>These builds are not meant to help gem progress, but to help build-up a specific perk.</p>
 <p><b>Important</b>: <b>R12</b> and above Get <b>Know Your Enemy Part 1</b> Artifact from the build below, it will help out quite a bit. Also at <b>R76</b> Get <b>Know Your Enemy Part 2</b> before you use all your Excavations.</p>


### PR DESCRIPTION
Changes all instances of

`All builds comes from the megathread forum page`

to

`All builds come from the megathread forum page`.

and

`(150 * L ^ 2.25), where x is Lineage level.`

to

`(150 * L ^ 2.25), where L is Lineage level.`
