### PR TITLE
Lineage Cost Calculator and other fixes

### DIFF
--- a/Bloodline/index.php
+++ b/Bloodline/index.php
@@ -14,18 +14,18 @@
 <p><b>In-game description</b>:Increase the production of all buildings based on the time spent as faction of the bloodline you are using. While you are Mercenary, a fraction of the total time spent as mercenary is added to your Bloodstream bonus based on the amount of mercenary upgrades purchased in this game from the faction of the bloodline you are using.</p>
 <p><b>Cost</b>: 1Tg (1e93 coins), A1+ Free</p>
 <p><b>Effect</b>: Increases the production of all buildings based on the total time allied with the faction bloodline you are playing. ('Time Spent Allied with' at the bottom of the stats)</p>
-<p><b>Formula</b>: 0.1*x^0.65%, where x is your (adjusted) time spent affiliated with the bloodline's faction in seconds.</p>
+<p><b>Formula</b>: 0.1 * x ^ 0.65%, where x is your (adjusted) time spent affiliated with the bloodline's faction in seconds.</p>
 <p><b>R28+</b></b>: Starting from R28, you might get Bloodspring research upgrade, that will grant you bloodline of the faction you're currently playing, in addition to the bloodline that you have chosen by basic upgrade.</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/FairyBloodline.png" alt="fairy" align="middle"><b> Fairy</b></p>
 <p><b>Effect</b>: Increase the production of Farm, Inn and Blacksmith based on the assistants you own.</p>
-<p><b>Formula</b>: 250 * x^0.9%, where x is the number of assistants you have.</p>
+<p><b>Formula</b>: 250 * x ^ 0.9%, where x is the number of assistants you have.</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenBloodline.png" alt="Elven" align="middle"><b> Elven</b></p>
 <p><b>Effect</b>: Increase the chance to find Faction Coins based on Faction Coins found in this game and autoclick 3 times per second. Autoclicks made this way benefit from a 100 times higher clicking reward and Faction Coin find chance.</p>
-<p><b>Formula</b>: floor(15 * ln(1 + x)^1.75), where x is number of Faction Coins found in this game.</p>
+<p><b>Formula</b>: floor(15 * ln(1 + x) ^ 1.75), where x is number of Faction Coins found in this game.</p>
 <p><b>Effect</b>: Multiplies Faction Coin find chance based on clicks made.</p>
-<p><b>Formula</b>: floor(log10( 1 + x) * 10)</p>
+<p><b>Formula</b>: floor(log10(1 + x) * 10)</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/AngelBloodline.png" alt="Angel" align="middle"><b> Angel</b></p>
 <p><b>Effect</b>: Increase mana regeneration based on spells cast this game.</p>
@@ -37,7 +37,7 @@
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadBloodline.png" alt="Undead" align="middle"><b> Undead</b></p>
 <p><b>Effect</b>: Gain additional assistants based on the amount of times you reincarnated.</p>
-<p><b>Formula</b>: floor(8*x^0.8), where x is the number of times you have reincarnated.</p>
+<p><b>Formula</b>: floor(8 * x ^ 0.8), where x is the number of times you have reincarnated.</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/DemonBloodline.png" alt="Demon" align="middle"><b> Demon</b></p>
 <p><b>Effect</b>: Increase production bonus from gems based on total time spent being Evil.</p>
@@ -57,35 +57,33 @@
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/DwarvenBloodline.png" alt="Dwarf" align="middle"><b> Dwarf</b></p>
 <p><b>Effect</b>: Increase the production of all buildings based on the amount of excavations you made.</p>
-<p><b>Formula</b>: 10 * x^0.8%, where x is your number of excavations purchased.</p>
+<p><b>Formula</b>: 10 * x ^ 0.8%, where x is your number of excavations purchased.</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/DrowBloodline.png" alt="Drow" align="middle"><b> Drow</b></p>
 <p><b>Effect</b>: Multiplicatively increase the chance to find Faction Coins based on time spent in this game.</p>
-<p><b>Formula</b>: 1.6*x^0.6, where x is time spent in this game in seconds.</p>
+<p><b>Formula</b>: 1.6 * x ^ 0.6, where x is time spent in this game in seconds.</p>
 <hr>
 <p><img src="http://musicfamily.org/realm/Factions/picks/DragonBloodline.png" alt="Dragon" align="middle"><b> Dragon</b></p>
 <p><b>Effect</b>: Increase the production of all buildings based on Faction Coin find chance.</p>
 <p><b>Formula</b>: 4 * (x ^ 0.4), where x is Faction Coin find chance.</p>
 <hr>
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonBloodline.png" align="middle"> Archon</p></b>
-<p><b>Requirements</b>: R130+</p>
+<p><b>Requirements</b>: Archon Unlocked, R130+</p>
 <p><b>Effect</b>: Gain additional research slots based on time spent this game.</p>
 <p><b>Formula</b>: (1 + floor(0.5 * ((1 + x / 10800) ^ 0.5 - 1))), where x is time spent this game.</p>
 <hr>
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnBloodline.png" align="middle"> Djinn</p></b>
-<p><b>Requirements</b>: R130+</p>
-<p><b>Effect</b>: Gain a new spell that costs 500,000 mana and lasts 1 minute as a fixed duration. Each time you cast it, it activates a vanilla or primary alignment spell at tier 7.</p>
+<p><b>Requirements</b>: Djinn Unlocked, R130+</p>
+<p><b>Effect</b>: Gain a new spell that costs 500,000 mana and lasts 1 minute as a fixed duration. Each time you cast it, it activates a vanilla or primary alignment spell at Tier 7.</p>
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/CatalystSpell.png"></p></b>
 <p><b>Notes</b>
-<p><b>1</b>. Spell comes with tier bonus.
-<p><b>2</b>. Choosing this Bloodline or having/buying A400 with Djinn gives you the vanilla spell upgrades that enable the challenge reward when bought.</p>
-<p><b>3</b>. Cannot cast a spell that is already active
-<p><b>4</b>. The Spell Pool is 8 for Neutral factions (No Gem Grinder), 7 for Good/Evil (-1 faction and -1 alignment spell)</p>
+<p><b>1</b>. Choosing this Bloodline or having/buying A400 with Djinn gives you the vanilla spell upgrades that enable the challenge reward when bought.</p>
+<p><b>2</b>. Cannot cast a spell that is already active.
+<p><b>3</b>. The Spell Pool is 8 for Neutral factions (No Gem Grinder), 7 for Good/Evil (-1 faction and -1 alignment spell)</p>
 <hr>
 <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersBloodline.png" align="middle"> Makers</p></b>
-<p><b>Requirements</b>: R130+</p>
+<p><b>Requirements</b>: Makers Unlocked, R130+</p>
 <p><b>Effect</b>: Increase your Set power based on faction coins collected this game.</p>
 <p><b>Formula</b>: (0.75 * log10(1 + x) ^ 1.5), where x is coins collected this game.</p>
-<p><b>Note</b> Includes Dwarf 5.</p>
 <br/>
 <?php include "../scripts/footer.html"; ?>

--- a/Lineages/index.php
+++ b/Lineages/index.php
@@ -49,6 +49,60 @@
             </div>
         </div>
     </div>
+    <div id="ReiCosCal" class="calculator">
+        <table>
+            <tr>
+                <th style="width : 72px"> Lineage level
+                <th style="width : 75px"> Heirloom Active
+                <th style="width : 75px"> Hourglass Active
+                <th class="HourglassRelated"> Reincarnation
+                <th style="width: 90px" class="HourglassRelated"> Time Passed (Hours)
+                <th> Cost for next Lineage level
+            </tr>
+            <tr>
+                <td ><input id="LineageLevel" type="number" min="0" max="100" value="0"></td>
+                <td ><input id="Heirloom" type="checkbox"></td>
+                <td ><input id="Hourglass" type="checkbox"></td>
+                <td class="HourglassRelated"><input id="HourglassR" type="number" min="100" max="159" value="100"></td>
+                <td class="HourglassRelated"><input id="HourglassT" type="number" min="0" value="0"></td>
+                <td id = "LineageNextLevel">
+            </tr>
+        </table>
+        <script>
+            function ShowAndHide() {
+              $('.HourglassRelated').css('display', 'none');
+              if($('#Hourglass').is(':checked')) {
+                $('.HourglassRelated').css('display', 'table-cell');
+              }
+            }
+            function HourglassCalc(lineageLevel) {
+              if(!$('#Hourglass').is(':checked')) {
+                return 0;
+              }
+              var time = parseInt($('#HourglassT').val());
+              var reincarnation = parseInt($('#HourglassR').val());
+              var redexp = Math.max(0.01,0.9-0.01*(((Math.max(1,lineageLevel-20))**1.4) - reincarnation/4));
+              var reduction = (0.1*Math.floor(time**redexp));
+              return reduction;
+            }
+            function calcCost() {
+              var lin = parseInt($('#LineageLevel').val());
+              var heirloom = $('#Heirloom').is(':checked');
+              lin = 25 * 10 ** (15 + lin - HourglassCalc(lin));
+              lin = lin**(1 - 0.1 * heirloom);
+              return lin;
+            }
+            function calcNextLineageCost() {
+              ShowAndHide();
+              var cost = calcCost();
+              cost = Math.floor(cost).toPrecision(4);
+              $('#LineageNextLevel').text(cost);
+            }
+            calcNextLineageCost();
+            $('#LineageLevel, #HourglassR, #HourglassT').on('input', calcNextLineageCost);
+            $('#Heirloom, #Hourglass').on('change', calcNextLineageCost);
+        </script>
+    </div>
     <p>You can get Lineage for each Faction (12 in Total, 15 in R130+)</p>
     <p>You get 3 perks and a Faction Coin boost plus Champion trophy after reaching level 20.</p>
     <p><b>level 5</b>: Perk 1</p>

--- a/Reincarnation/index.php
+++ b/Reincarnation/index.php
@@ -24,10 +24,10 @@
             <tr>
                 <th>
                     Complete list of Reincarnation benefits:
-                    <input id="ReiCosRei" type="number" min="0" max="160" value="0">
-                    <span id="R10"> with time(total) <input id="R10TimTot" type="number" min="0" max="876000" value="1"> in hours</span>
-                    <span id="R20"> and <input id="R20SpeBui" type="number" min="0" max="9999999" value="1"> buildings of given type.</span>
-                    <span id="R63"> Prismatic Breath active? <input id="R63PB" type="checkbox"></span>
+                    <input id="ReiCosRei" style="max-width: 15%" type="number" min="0" max="160" value="0">
+                    <span id="R10"> with time(total) <input id="R10TimTot" style="max-width: 15%" type="number" min="0" max="876000" value="1"> in hours</span>
+                    <span id="R20"> and <input id="R20SpeBui" style="max-width: 15%" type="number" min="0" max="9999999" value="1"> buildings of given type.</span>
+                    <span id="R63"> Prismatic Breath active? <input id="R63PB" style="width: unset"  type="checkbox"></span>
                 </th>
             </tr>
             <tr>

--- a/Rubies/index.php
+++ b/Rubies/index.php
@@ -15,14 +15,14 @@
         <table>
             <tbody><tr><th colspan="8">Ruby Excavation Count and Cost</th></tr>
             <tr>
-                <th>Ruby</th>
-                <th>E290</th>
-                <th>Easter</th>
-                <th>Maker</th>
-                <th>Ascension</th>
-                <th>Excavation</th>
-                <th>Coins</th>
-                <th>Gems</th>
+                <th style="width: 10%">Ruby</th>
+                <th style="width: 8%">E290</th>
+                <th style="width: 7%">Easter</th>
+                <th style="width: 12.5%">Maker</th>
+                <th style="width: 15%">Ascension</th>
+                <th style="width: 15%">Excavation</th>
+                <th style="width: 15%">Coins</th>
+                <th style="width: 15%">Gems</th>
             </tr>
             <tr>
                 <td><input id="rub" type="number" min="1" max="99" value="1"></td>

--- a/Spells/index.php
+++ b/Spells/index.php
@@ -289,19 +289,19 @@
     <div id="SSCal" class="calculator">
         <table>
             <tr>
-                <th style="width:100px; height: 35px" rowspan="2">Reincarnation</th>
+                <th style="width:100px; height: 68px" rowspan="2">Reincarnation</th>
                 <th style="width:55px" class="SSCalTieHid" rowspan="2">Tier</th>
-                <th style="width:55px" class="SSCalDDLinHid" rowspan="2">Active Druid Lineage Level</th>
+                <th style="width:80px" class="SSCalDDLinHid" rowspan="2">Active Druid Lineage Level</th>
                 <th style="width:55px" class="SSCalDra" title="Prismatic Breath" rowspan="2">PB</th>
                 <th colspan="2">Production bonus</th>
-                <th style="width:120px" class="ResUnl" rowspan="2">D1375 production bonus</th>
+                <th style="width:100px" class="ResUnl" rowspan="2">D1375 production bonus</th>
             </tr>
             <tr class="ResUnl">
                 <th>without D1375</th>
                 <th>with D1375</th>
             </tr>
             <tr>
-                <td><input id="SSCalRei" type="number" min="14" max="157" value="14"></td>
+                <td><input id="SSCalRei" type="number" min="14" max="159" value="14"></td>
                 <td class="SSCalTieHid"><input id="SSCalTie" type="number" min="1" max="7" value="1"></td>
                 <td class="SSCalDDLinHid"><input id="SSCalDDLin" type="number" min="0" value="0"></td>
                 <td class="SSCalDra" title="Prismatic Breath"><input id="SSCalPB" type="checkbox"></td>
@@ -871,7 +871,7 @@
     <hr>
     <p><b><center>Ascension 1</center></p></b>
     <p><b><center>Alignment Spells</center></p></b>
-    <p><b><img src="http://musicfamily.org/realm/Factions/picks/DragonsBreath.png" alt="Neutral" align="middle"> Dragons Breath</b> (Dragon)</p>
+    <p><b><img src="http://musicfamily.org/realm/Factions/picks/DragonsBreath.png" alt="Neutral" align="middle"> Dragon's Breath</b> (Dragon)</p>
     <p><b>Works For</b>: Dragon - <b>Cost</b>: 1500 Mana - <b>Duration</b>: 20 seconds</p>
     <p><b>Description</b>: Increase the production of all buildings based on Dragon's Breath activity time. ({1 * x ^ 0.625}%)</p>
     <p><b>Name</b>: Dragon's Breath</p>
@@ -924,14 +924,14 @@
     </div>
 <br/>
     <p><b>Mercenary</b>: Tax Collection</p>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/ShareBenefitsSpell.png" alt="Round Table" align="middle"> <b>Share Benefits</b> (Mercenary Good Alignment)</p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/ShareBenefitsSpell.png" alt="Round Table" align="middle"> <b>Share Benefits</b> (Good Mercenaries)</p>
     <p><b>Requirement</b>: Mercenary Camp</p>
     <p><b>Cost</b>: 1 Qaqag (1e135)</p>
     <p><b>Effect</b>: Increases the production of all buildings and Faction Coin find chance based on this spell tier level for 20 seconds. Can be cast up to 36 tiers.</p>
     <p><b>Formula</b>: 120 ^ (0.25 * t), where t is tier (FC chance multiplier)</p>
     <p><b>Formula</b>: ((2.20 ^ T) - 1) * 100, multiplicative (production multiplier)</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/ReapInterestsSpell.png" alt="Tyrant Garrison" align="middle"> <b>Reap Interests </b> (Mercenary Evil Alignment)</p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/ReapInterestsSpell.png" alt="Tyrant Garrison" align="middle"> <b>Reap Interests </b> (Evil Mercenaries)</p>
     <p><b>Requirement</b>: Tyrant Garrison</p>
     <p><b>Cost</b>: 1 Qaqag (1e135)</p>
     <p><b>Effect</b>: Additional casts of Reap Interests increase its seconds worth of production.</p>
@@ -942,7 +942,7 @@
     <p><b>Note</b>: Extra time from reap interests does apply to S50.</p>
     <p><b>Note</b>: S50 tax collections do increase reap interests.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/AppraisalVantageSpell.png" alt="Freemason's Hall" align="middle"> <b>Appraisal Vantage</b> (Mercenary Neutral Alignment)</p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/AppraisalVantageSpell.png" alt="Freemason's Hall" align="middle"> <b>Appraisal Vantage</b> (Neutral Mercenaries)</p>
     <p><b>Requirement</b>: Freemason's Hall</p>
     <p><b>Cost</b>: 1 Qaqag (1e135)</p>
     <p><b>Effect</b>: Generates additional Faction Coins per cast</p>
@@ -981,7 +981,7 @@
                 <p><b>Coin Cost</b>: 123 Qaq (1.23e125) Emerald coins
                 <p><b>FC Cost</b>: 1 Oc (1e27) Fairy, Demon, Dwarven and Drow Coins.</p>
        <br/>
-                <p><img src="http://musicfamily.org/realm/Factions/picks/AllCreationSpell.png" alt="All Creation" align="middle"> <b>All Creation</b> (Proof Of Balance) </p
+                <p><img src="http://musicfamily.org/realm/Factions/picks/AllCreationSpell.png" alt="All Creation" align="middle"> <b>All Creation</b> (Proof Of Balance) </p>
                 <p><b>Requirement</b>: Ascension 2</p>
                 <p><b>Cost</b>: 6000 Mana</p>
                 <p><b>Effect</b>: Increase production of all buildings based on mana regeneration rate.</p>
@@ -996,7 +996,7 @@
                 <p><b>FC Cost</b>: 1 Oc (1e27) Elven, Goblin, Dwarven and Drow Coins.</p>
        <hr>
     <p><b><center>Ascension 2</center></b></p>
-    <p><b><center>Third Alignment Spells</center></b></p>
+    <p><b><center>Elite Faction Spells</center></b></p>
                 <p><img src="http://musicfamily.org/realm/Factions/picks/PrecognitionSpell.png" alt="All Creation" align="middle"> <b>Precognition</b> (Archons)</p>
 <p><b>Cost</b>: 123456 mana</p>
 <p><b>Effect</b>: Buildings, Assistants, Royal Exchanges, Spells cast and Clicks count more based on mana produced in this game.</p>
@@ -1011,9 +1011,9 @@
 <br/>
                 <p><img src="http://musicfamily.org/realm/Factions/picks/LimitedWishSpell.png" alt="Limited wish" align="middle"> <b>Limited Wish</b> (Djinns)</p>
 <p><b>Cost</b>: 888888 mana</p>
-<p><b>Effect</b>: Provide a random effect based on your chosen alignment, for 12 seconds. The duration of the spell cannot be modified. Its power increases as you continue casting this spell.</p>
+<p><b>Effect</b>: Provide a random effect based on your chosen base alignment, for 12 seconds. The duration of the spell cannot be modified. Its power increases as you continue casting this spell.</p>
 <p><b>Possible Effects</b>
-<p><b>Good</b></p>
+<p><b>Good</b>: </p>
 <p><b>1</b>: Increase the production of all buildings</p>
 <p><b>2</b>: Increase Assistants</p>
 <p><b>3</b>: All spells durations count more</p>


### PR DESCRIPTION
The rubies table fix had some annoying consequences with table widths but I fixed it. Added a lineage calculator whilst I was doing so.

Lineages: A lineage cost calculator. Calculates heirloom and hourglass. Accurate to game code.

Spells: Added widths to tables to look nicer. Fixed small typos.

Rubies: Re-added widths to tables.

Bloodline: Small grammar fixes, add faction requirement to elite bloodlines. Minor adjustment to Catalyst's description.

Reincarnation: Fixed widths on tables.