### PR TITLE
note mentioning future linkin

### DIFF
--- a/R116Plus/index.php
+++ b/R116Plus/index.php
@@ -386,6 +386,7 @@
                 <p>A300,A1200,A3400,</p>
                 <p>W275,W1375,W1400</p>
                 <p><b>Notes</b>: Buffing W275 is highly recommended.</p>
+                <p><b>Notes</b>: Future Linkin is also highly recommended.</p>
                 <p><b>Notes</b>: Leveling Undead to L30 first is fastest.</p>
             </div>
         </div>


### PR DESCRIPTION
Added a note that recommends having future linking for the "Faceless Lineage Leveler (L30)" as this trophy can be sometimes overlooked/forgotten.