### PR TITLE
Lineage page updating

### DIFF
--- a/Lineages/index.php
+++ b/Lineages/index.php
@@ -111,18 +111,18 @@
     <center><b>Lineage Menu</b></center>
     <center><img src="http://musicfamily.org/realm/Factions/picks/Lineages.png" usemap="#Lineages-map"></center>
     <map name="Lineages-map">
-        <area href="#Fairy" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/FairyLineage.png align=middle> Fairy Lineage</b><p><b>Base Effect</b>: Makes Farms, Inns and Blacksmiths count 18% more per Lineage level.<p><b>Cost</b>: 400 Fairy Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,14,68,69" shape="rect">
-        <area href="#Elf" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/ElvenLineage.png align=middle> Elven Lineage</b><p><b>Base Effect</b>: Gives 1 autoclick per Lineage level. Also increases clicks count by 5000% per level.<p><b>Cost</b>: 400 Elven Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,14,131,67" shape="rect">
-        <area href="#Angel" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/AngelLineage.png align=middle> Angel Lineage</b><p><b>Base Effect</b>: Adds 7% mana regeneration per level.<p><b>Cost</b>: 400 Angel Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,16,188,67" shape="rect">
-        <area href="#Goblin" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/GoblinLineage.png align=middle> Goblin Lineage</b><p><b>Base Effect</b>: Increase Tax Collection worth in seconds by 25 for every level.<p><b>Cost</b>: 400 Goblin Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,76,68,125" shape="rect">
-        <area href="#Undead" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/UndeadLineage.png align=middle> Undead Lineage</b><p><b>Base Effect</b>: +1% more Assistants per level.<p><b>Cost</b>: 400 Undead Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,75,130,127" shape="rect">
-        <area href="#Demon" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DemonLineage.png align=middle> Demon Lineage</b><p><b>Base Effect</b>: Increase Non-Unique Buildings production based on Lineage level. Does not suffer from Ascension penalties.</p><p><b>Formula</b>: (100 * x ^ 2), where x is Lineage level.</p><p><b>Cost</b>: 400 Demon Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,73,191,127" shape="rect">
-        <area href="#Titan" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/TitanLineage.png align=middle> Titan Lineage</b><p><b>Base Effect</b>: Increase Royal Exchange Bonus and Royal Exchange Count by 200% for every level.<p><b>Cost</b>: 400 Angel and 400 Goblin Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,135,68,187" shape="rect">
-        <area href="#Druid" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DruidLineage.png align=middle> Druid Lineage</b><p><b>Base Effect</b>: Each lineage level counts as 2 additional Reincarnations.<p><b>Cost</b>: 400 Elven and 400 Demon Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,133,130,187" shape="rect">
-        <area href="#Faceless" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/FacelessLineage.png align=middle> Faceless Lineage</b><p><b>Base Effect</b>:  Increase the duration of all spells based on lineage level<p>Formula: (x ^ 2)%, where x is lineage level.<p><b>Cost</b>: 400 Fairy and 400 Undead Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,134,190,187" shape="rect">
-        <area href="#Dwarf" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DwarfLineage.png align=middle> Dwarven Lineage</b><p><b>Base Effect</b>: Increase the base production of each building based on their tier (additively). The bonus is multiplied by the Lineage level.</p><p><b>Formula</b>: (L * 10 ^ (0.2 * T  ^ 1.4)), where L is Lineage level and T is Building tier.</p><p><b>Cost</b>: 400 Dwarven Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,193,70,246" shape="rect">
-        <area href="#Drow" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DrowLineage.png align=middle> Drow Lineage</b><p><b>Base Effect</b>: Increase offline production bonus based on Lineage level.</p><p><b>Formula</b>: (150 * L ^ 2.25), where x is Lineage level. Not affected by Ascension nerfs.</p><p><b>Cost</b>: 400 Drow Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,193,128,247" shape="rect">
-        <area href="#Dragon" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DragonLineage.png align=middle> Dragon Lineage</b><p><b>Base Effect</b>: Unique Buildings count as 12% more per level for all purposes.<p><b>Cost</b>: 400 Dwarven and 400 Drow Royal Exchanges.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,193,190,246" shape="rect">
+        <area href="#Fairy" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/FairyLineage.png align=middle> Fairy Lineage</b><p><b>Base Effect</b>: Makes Farms, Inns and Blacksmiths count 18% more per Lineage level.<p><b>Cost</b>: 400 Fairy Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,14,68,69" shape="rect">
+        <area href="#Elf" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/ElvenLineage.png align=middle> Elven Lineage</b><p><b>Base Effect</b>: Gives 1 autoclick per Lineage level. Also increases clicks count by 5000% per level.<p><b>Cost</b>: 400 Elven Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,14,131,67" shape="rect">
+        <area href="#Angel" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/AngelLineage.png align=middle> Angel Lineage</b><p><b>Base Effect</b>: Adds 7% mana regeneration per level.<p><b>Cost</b>: 400 Angel Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,16,188,67" shape="rect">
+        <area href="#Goblin" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/GoblinLineage.png align=middle> Goblin Lineage</b><p><b>Base Effect</b>: Increase Tax Collection worth in seconds by 25 for every level.<p><b>Cost</b>: 400 Goblin Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,76,68,125" shape="rect">
+        <area href="#Undead" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/UndeadLineage.png align=middle> Undead Lineage</b><p><b>Base Effect</b>: +1% more Assistants per level.<p><b>Cost</b>: 400 Undead Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,75,130,127" shape="rect">
+        <area href="#Demon" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DemonLineage.png align=middle> Demon Lineage</b><p><b>Base Effect</b>: Increase Non-Unique Buildings production based on Lineage level. Does not suffer from Ascension penalties.</p><p><b>Formula</b>: (100 * x ^ 2), where x is Lineage level.</p><p><b>Cost</b>: 400 Demon Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,73,191,127" shape="rect">
+        <area href="#Titan" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/TitanLineage.png align=middle> Titan Lineage</b><p><b>Base Effect</b>: Increase Royal Exchange Bonus and Royal Exchange Count by 200% for every level.<p><b>Cost</b>: 400 Angel and 400 Goblin Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,135,68,187" shape="rect">
+        <area href="#Druid" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DruidLineage.png align=middle> Druid Lineage</b><p><b>Base Effect</b>: Each lineage level counts as 2 additional Reincarnations.<p><b>Cost</b>: 400 Elven and 400 Demon Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,133,130,187" shape="rect">
+        <area href="#Faceless" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/FacelessLineage.png align=middle> Faceless Lineage</b><p><b>Base Effect</b>:  Increase the duration of all spells based on lineage level<p>Formula: (x ^ 2)%, where x is lineage level.<p><b>Cost</b>: 400 Fairy and 400 Undead Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,134,190,187" shape="rect">
+        <area href="#Dwarf" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DwarfLineage.png align=middle> Dwarven Lineage</b><p><b>Base Effect</b>: Increase the base production of each building based on their tier (additively). The bonus is multiplied by the Lineage level.</p><p><b>Formula</b>: (L * 10 ^ (0.2 * T  ^ 1.4)), where L is Lineage level and T is Building tier.</p><p><b>Cost</b>: 400 Dwarven Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="17,193,70,246" shape="rect">
+        <area href="#Drow" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DrowLineage.png align=middle> Drow Lineage</b><p><b>Base Effect</b>: Increase offline production bonus based on Lineage level.</p><p><b>Formula</b>: (150 * L ^ 2.25), where x is Lineage level. Not affected by Ascension nerfs.</p><p><b>Cost</b>: 400 Drow Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="77,193,128,247" shape="rect">
+        <area href="#Dragon" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DragonLineage.png align=middle> Dragon Lineage</b><p><b>Base Effect</b>: Unique Buildings count as 12% more per level for all purposes.<p><b>Cost</b>: 400 Dwarven and 400 Drow Royal Exchanges<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at." coords="137,193,190,246" shape="rect">
         <area href="#Archon" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/ArchonLineage.png align=middle> Archon Lineage</b></p> <p><b>Requirements</b>: R130+</p> <p><b>Cost</b>: 400 Angel, Undead Royal Exchanges</p> <p><b>Effect</b>: Increase Faction Coin find chance multiplicatively by 20% per level.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at.</p>" coords="18,257,68,305" shape="rect">
         <area href="#Djinn" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/DjinnLineage.png align=middle> Djinn Lineage</b></p> <p><b>Requirements</b>: R130+</p> <p><b>Cost</b>: 400 Fairy, Demon Royal Exchanges</p> <p><b>Effect</b>: Increase production bonus from gems by a multiplicative 8% for every level.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at.</p>" coords="78,255,128,306" shape="rect">
         <area href="#Makers" target="" research="<p><b><img src=http://musicfamily.org/realm/Factions/picks/MakersLineage.png align=middle> Makers Lineage</b></p> <p><b>Requirements</b>: R130+</p> <p><b>Cost</b>: 400 Elven, Goblin Royal Exchanges</p> <p><b>Effect</b>: Increase Royal Exchange bonus by multiplicative 8% per level.<p>Lineages needs bought every Abdication and Reincarnation and Levels only need bought once.<p>Pointing to this ingame will tell you what level it is at.</p>" coords="136,255,190,305" shape="rect">
@@ -130,12 +130,12 @@
     <hr>
     <H6 id="Fairy">Fairy</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FairyLineage.png" align="middle"><b> Fairy Lineage</b></p>
-    <p><b>Cost</b>: 400 Fairy Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Fairy Royal Exchanges</p>
     <p><b>Effect</b>: Makes Farms, Inns and Blacksmiths count 18% more per Lineage level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FairyPerk1.png" align="middle"><b> Fairy Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Makes Fairy Bloodline affect Hall of Legends.</p>
     <p><b>Effect</b>: Also reduces Fairy Bloodline Post Ascension nerf.</p>
     <p><b>Formula</b>: (250 * (a ^ 0.9)), A1 nerf removed</p>
@@ -145,7 +145,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FairyPerk2.png" align="middle"><b> Fairy Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Fairy Lineage Challenge.</p>
     <p><b>Challenge</b>: 2k Assistants in less than 10 minutes.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Fairy Chanting)</p>
@@ -155,7 +155,7 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: Gain 1% more assistants for every 2000 Unique Buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/FairyGrandChampionTrophy.png" align="middle"> <b>Fairy Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/FairyGrandChampionTrophy.png" align="middle"> <b>Fairy Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Fairy Lineage to level 20 and purchase 3 Fairy Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -166,18 +166,18 @@
     <br/>
     <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/FairyPerk5.png" align="middle"> Fairy Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Assistants count 300% more.</p>
     <hr>
     <H6 id="Elf">Elven</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenLineage.png" align="middle"><b> Elven Lineage</b></p>
-    <p><b>Cost</b>: 400 Elven Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Elven Royal Exchanges</p>
     <p><b>Effect</b>: Gives 1 autoclick per Lineage level.</p>
     <p><b>Effect</b>: Also increases clicks count by 5000% per level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenPerk1.png" align="middle"><b> Elven Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Increase autoclicks provided by Elven Bloodlines to 9 per second and their multiplier to x10000.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -185,7 +185,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenPerk2.png" align="middle"><b> Elven Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Elven Lineage Challenge.</p>
     <p><b>Challenge</b>: 7777 autoclicks in the first 5 minutes of a run.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Moon Blessing)</p>
@@ -196,7 +196,7 @@
     <p><b>Effect</b>: Increase base clicking reward by 15% of Unique Building production for every 777 of them.</p>
     <p><b>Formula</b>: (15 * floor(x / 777))</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenGrandChampionTrophy.png" align="middle"> <b>Elven Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/ElvenGrandChampionTrophy.png" align="middle"> <b>Elven Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Elven Lineage to level 20 and purchase 3 Elven Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -204,19 +204,19 @@
     <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
     <p><b>Effect</b>: When Moon Blessing is active, multiply your fc chance by 1500%.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ElvenPerk5.png" align="middle"> Elven Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Faction Coins count 1000% more.</p>
     <hr>
     <H6 id="Angel">Angel</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/AngelLineage.png" align="middle"><b> Angel Lineage</b></p>
-    <p><b>Cost</b>: 400 Angel Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Angel Royal Exchanges</p>
     <p><b>Effect</b>: Adds 7% mana regeneration per level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/AngelPerk1.png" align="middle"><b> Angel Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Angel Bloodline effect now counts total spells cast this R.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -224,7 +224,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/AngelPerk2.png" align="middle"><b> Angel Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Angel Lineage Challenge.</p>
     <p><b>Challenge</b>: Play 2 hours straight with at least 1 spell active.</p>
     <p><b>Note</b>: This must be done within first 2 hours and 1 minute since start of run.</p>
@@ -236,7 +236,7 @@
     <p><b>Effect</b>: Increase God's Hand bonus based on Unique Buildings owned.</p>
     <p><b>Formula</b>: (12000 * (x / 1000))%, Unique Buildings.(rounded down to nearest 1000)</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/AngelGrandChampionTrophy.png" align="middle"> <b>Angel Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/AngelGrandChampionTrophy.png" align="middle"> <b>Angel Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Angel Lineage to level 20 and purchase 3 Angel Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -244,19 +244,19 @@
     <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
     <p><b>Effect</b>: When God's Hand is active, increase max mana by 50%.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/AngelPerk5.png" align="middle"> Angel Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Spells cast count 1000% more.</p>
     <hr>
     <H6 id="Goblin">Goblin</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/GoblinLineage.png" align="middle"><b> Goblin Lineage</b></p>
-    <p><b>Cost</b>: 400 Goblin Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Goblin Royal Exchanges</p>
     <p><b>Effect</b>: Increase Tax Collection worth in seconds by 25 for every level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/GoblinPerk1.png" align="middle"><b> Goblin Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: When using Goblin Bloodline, Tax Collections are worth more seconds based on the amount of assistants you own.</p>
     <p><b>Formula</b>: (0.75 * x ^ 0.25), where x is amount of assistants you own.</p>
     <br/>
@@ -265,7 +265,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/GoblinPerk2.png" align="middle"><b> Goblin Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Goblin Lineage Challenge.</p>
     <p><b>Challenge</b>: Cast 1 million TCs in a single game.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Goblin's Greed)</p>
@@ -275,7 +275,7 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: Unique Building's base production increased by 25% for every 650 Unique Buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/GoblinGrandChampionTrophy.png" align="middle"> <b>Goblin Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/GoblinGrandChampionTrophy.png" align="middle"> <b>Goblin Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Goblin Lineage to level 20 and purchase 3 Goblin Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -285,19 +285,19 @@
     <p><b>Formula</b>: (20 + ln(1 + x) ^ 1.85), where x is Gems required for your next Reincarnation.</p>
     <p><b>Effect</b>: Also makes Tax Collection casts count 100% more.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/GoblinPerk5.png" align="middle"> Goblin Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Increase Faction Coin Find Chance by 1000%.</p>
     <hr>
     <H6 id="Undead">Undead</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadLineage.png" align="middle"><b> Undead Lineage</b></p>
-    <p><b>Cost</b>: 400 Undead Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Undead Royal Exchanges</p>
     <p><b>Effect</b>: +1% more Assistants per level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadPerk1.png" align="middle"><b> Undead Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Undead Bloodline multiplies your assistants by 8% of the amount instead of adding them.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -305,7 +305,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadPerk2.png" align="middle"><b> Undead Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Undead Lineage Challenge.</p>
     <p><b>Challenge</b>: Have Night Time's spell duration be 60 seconds.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Night Time)</p>
@@ -315,7 +315,7 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: Gain 10 assistants for every 500 Unique Buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadGrandChampionTrophy.png" align="middle"> <b>Undead Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/UndeadGrandChampionTrophy.png" align="middle"> <b>Undead Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Undead Lineage to level 20 and purchase 3 Undead Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -324,21 +324,21 @@
     <p><b>Effect</b>: Increase Offline Bonus based on Night Time activity time in this game.</p>
     <p><b>Formula</b>: (7 * x ^ 0.7), where x is Night Time activity time this game.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/UndeadPerk5.png" align="middle"> Undead Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Reincarnation Power Counts Reincarnations as 100% more.</p>
     <hr>
     <H6 id="Demon">Demon</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DemonLineage.png" align="middle"><b> Demon Lineage</b></p>
-    <p><b>Cost</b>: 400 Demon Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Demon Royal Exchanges</p>
     <p><b>Effect</b>: Increase Non-Unique Buildings production based on Lineage level. Ascension penalty reduces based on time this Reincarnation.</p>
     <p><b>Production Formula</b>: (100 * x ^ 2), where x is Lineage level.</p>
     <p><b>Ascension Penalty Reduction Formula</b>: (floor(log3(x / 28800 + 1)), where x is time this reincarnation in seconds. (16 hours for -1, 2 days 16 hours for -2)</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DemonPerk1.png" align="middle"><b> Demon Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: While using Demon Bloodline, increase Maximum Mana based on trophies unlocked.</p>
     <p><b>Formula</b>: (20 * x ^ 1.25), where x is trophies unlocked.</p>
     <br/>
@@ -347,7 +347,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DemonPerk2.png" align="middle"><b> Demon Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Demon Lineage Challenge.</p>
     <p><b>Challenge</b>: 2 days of HFB activity time (This R).</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Hellfire Blast)</p>
@@ -357,7 +357,7 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: Increase production bonus from Gems by 50% per 666 Unique Buildings (multiplicative)</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/DemonGrandChampionTrophy.png" align="middle"> <b>Demon Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/DemonGrandChampionTrophy.png" align="middle"> <b>Demon Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Demon Lineage to level 20 and purchase 3 Demon Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -365,18 +365,19 @@
     <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
     <p><b>Effect</b>: Non-Unique Buildings are also targeted by Hellfire Blast.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DemonPerk5.png" align="middle"> Demon Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Trophies count 1000% more.</p>
     <hr>
     <H6 id="Titan">Titan</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/TitanLineage.png" align="middle"><b> Titan Lineage</b></p>
-    <p><b>Cost</b>: 400 Angel and 400 Goblin Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Angel and 400 Goblin Royal Exchanges</p>
     <p><b>Effect</b>: Increase Royal Exchange Bonus and Royal Exchange Count by 200% for every level.</p>
+    <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/TitanPerk1.png" align="middle"><b> Titan Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Removes 1 Ascension penalty from Titan Bloodline.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -384,7 +385,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/TitanPerk2.png" align="middle"><b> Titan Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Titan Lineage Challenge.</p>
     <p><b>Challenge</b>: 25K mana per second as pure Titan. (so no Dragon Trade Treaty)</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Lightning Strike)</p>
@@ -395,7 +396,7 @@
     <p><b>Effect</b>: Increase the base production of tier 4 and tier 7 buildings based on Unique Buildings owned.</p>
     <p><b>Formula</b>: (0.01 * x and y), where x is tier 4 and tier 7, y is Unique Buildings owned.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/TitanGrandChampionTrophy.png" align="middle"> <b>Titan Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/TitanGrandChampionTrophy.png" align="middle"> <b>Titan Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Titan Lineage to level 20 and purchase 3 Titan Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -403,19 +404,19 @@
     <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
     <p><b>Effect</b>: Lightning Strike always hits Unique Buildings in addition to its random target. Unique Buildings are no longer random targets.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/TitanPerk5.png" align="middle"> Titan Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Royal Exchanges count 500% more.</p>
     <hr>
     <H6 id="Druid">Druid</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DruidLineage.png" align="middle"><b> Druid Lineage</b></p>
-    <p><b>Cost</b>: 400 Elven and 400 Demon Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Elven and 400 Demon Royal Exchanges</p>
     <p><b>Effect</b>: Each lineage level counts as 2 additional Reincarnations.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DruidPerk1.png" align="middle"><b> Druid Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Increases Non-Unique building production based on time spent in this game.</p>
     <p><b>Formula</b>: (0.25 * x ^ 1.25), where x is seconds this game.</p>
     <br/>
@@ -424,7 +425,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DruidPerk2.png" align="middle"><b> Druid Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Druid Lineage Challenge.</p>
     <p><b>Challenge</b>: Have a mana regeneration of at least double your max mana.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Grand Balance)</p>
@@ -435,7 +436,7 @@
     <p><b>Effect</b>: Increase Grand Balance bonus based on the amount of Unique Buildings you own.</p>
     <p><b>Formula</b>: (12000 * Floor(x / 1000)), where x is amount of Unique Buildings you own.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/DruidGrandChampionTrophy.png" align="middle"> <b>Druid Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/DruidGrandChampionTrophy.png" align="middle"> <b>Druid Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Druid Lineage to level 20 and purchase 3 Druid Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
@@ -446,20 +447,20 @@
     <p><b>Effect</b>: Also, while Grand Balance is active, increase the production of its targets based on Grand Balance duration.</p>
     <p><b>Formula</b>: ((x ^ 0.5) ^ (1 + 0.01 * y)), where x is spell duration in seconds and y is Grand Balance tier.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DruidPerk5.png" align="middle"> Druid Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Mana produced counts 1000% more.</p>
     <hr>
     <H6 id="Faceless">Faceless</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessLineage.png" align="middle"><b> Faceless Lineage</b></p>
-    <p><b>Cost</b>: 400 Fairy and 400 Undead Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Fairy and 400 Undead Royal Exchanges</p>
     <p><b>Effect</b>: Increase the duration of all spells based on lineage level</p>
     <p><b>Formula</b>: (x ^ 2)%, where x is lineage level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessPerk1.png" align="middle"><b> Faceless Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Faceless Bloodline counts total mana produced (This R) and increases mana per second based on the amount of assistants you own.</p>
     <p><b>Formula</b>: (0.95 * x ^ 0.95), where x is assistants you own</p>
     <br/>
@@ -468,7 +469,7 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessPerk2.png" align="middle"><b> Faceless Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Faceless Lineage Challenge.</p>
     <p><b>Challenge</b>: Cast 100 Brainwaves in a single game.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Brainwave)</p>
@@ -478,70 +479,70 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: 5% more assistant production per 1k Unique Buildings. (Does not suffer from Ascension penalties)</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessGrandChampionTrophy.png" align="middle"> <b>Faceless Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessGrandChampionTrophy.png" align="middle"> <b>Faceless Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Faceless Lineage to level 20 and purchase 3 Faceless Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/FacelessPerk4.png" align="middle"><b> Faceless Perk 4</b></p>
-    <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
+    <p><b>Requirement</b>: A2+, Reach Lineage Level 30</p>
     <p><b>Effect</b>: Remove 1 Ascension penalty from Brainwave on Unique Buildings.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/FacelessPerk5.png" align="middle"> Faceless Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Time passed counts 100% more.</p>
     <hr>
     <H6 id="Dwarf">Dwarven</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfLineage.png" align="middle"><b> Dwarven Lineage</b></p>
-    <p><b>Cost</b>: 400 Dwarven Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Dwarven Royal Exchanges</p>
     <p><b>Effect</b>: Increase the base production of each building based on their tier (additively).</p>
     <p><b>Note</b>: The bonus is multiplied by the Lineage level.</p>
     <p><b>Formula</b>: (L * 10 ^ (0.2 * T  ^ 1.4)), where L is Lineage level and T is Building tier.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfPerk1.png" align="middle"><b> Dwarven Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
-    <p><b>Effect</b>: Dwarven Bloodline increases faction coin find chance based on total time spent as Good. (1 day of Good = 19,520%).</p>
-    <p><b>Formula</b>: (50 * x ^ 0.75) where x is seconds of good alignment (this R)</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
+    <p><b>Effect</b>: Dwarven Bloodline increases Faction Coin find chance based on total time spent as Good. (1 day of Good = 19,520%).</p>
+    <p><b>Formula</b>: (50 * x ^ 0.75) where x is seconds of Good alignment (this R)</p>
     <br/>
     <p><b>Level 10</b></p>
     <p><b>Effect</b>: x100 Dwarven Faction Coin find chance.</p>
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfPerk2.png" align="middle"><b> Dwarven Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Dwarven Lineage Challenge.</p>
-    <p><b>Challenge</b>: Have 10k Excavations.</p>
+    <p><b>Challenge</b>: Have 10,000 Excavations.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Diamond Pickaxe)</p>
     <br/>
     <p><b>Level 20</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfPerk3.png" align="middle"><b> Dwarven Perk 3</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 20.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 20</p>
     <p><b>Effect</b>: Excavations and Artifacts count 1% more for every 1500 Unique Buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfGrandChampionTrophy.png" align="middle"> <b>Dwarven Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfGrandChampionTrophy.png" align="middle"> <b>Dwarven Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Dwarven Lineage to level 20 and purchase 3 Dwarven Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DwarfPerk4.png" align="middle"><b> Dwarven Perk 4</b></p>
-    <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
+    <p><b>Requirement</b>: A2+, Reach Lineage Level 30</p>
     <p><b>Effect</b>: When Diamond Pickaxe is active, increase mana regen based on Faction Coin chance.</p>
     <p><b>Formula</b>: (0 .5 * log10(x + 1) ^ 2.5), where x is Faction Coin chance.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DwarvenPerk5.png" align="middle"> Dwarven Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Buildings count 100% more.</p>
     <hr>
     <H6 id="Drow">Drow</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowLineage.png" align="middle"><b> Drow Lineage</b></p>
-    <p><b>Cost</b>: 400 Drow Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Drow Royal Exchanges</p>
     <p><b>Effect</b>: Increase offline production bonus based on Lineage level. Not affected by Ascension nerfs.</p>
     <p><b>Formula</b>: (150 * L ^ 2.25), where L is Lineage level.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk1.png" align="middle"><b> Drow Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: While using Drow Bloodline, all time spent counts 100% more for all purposes.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -549,39 +550,39 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk2.png" align="middle"><b> Drow Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Drow Lineage Challenge.</p>
     <p><b>Challenge</b>: 30 days offline across all Reincarnations.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Combo Strike)</p>
     <br/>
     <p><b>Level 20</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk3.png" align="middle"><b> Drow Perk 3</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 20.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 20</p>
     <p><b>Effect</b>: Increase Faction Coin find chance by 5% per 3000 unique buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/DrowGrandChampionTrophy.png" align="middle"> <b>Drow Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/DrowGrandChampionTrophy.png" align="middle"> <b>Drow Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Drow Lineage to level 20 and purchase 3 Drow Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk4.png" align="middle"><b> Drow Perk 4</b></p>
-    <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
+    <p><b>Requirement</b>: A2+, Reach Lineage Level 30</p>
     <p><b>Effect</b>: Combo Strike's combo bonus increases by 5% per 30 seconds spent this game.</p>
     <p><b>Effect</b>: While Combo Strike is active, increase the production of all buildings based on the current Combo Strike bonus.</p>
     <p><b>Formula</b>: (2 * log10((x ^ 0.9) ^ T) ^ 2) where x is combo count, and T is spell tier.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DrowPerk5.png" align="middle"> Drow Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Maximum Mana counts 300% more.</p>
     <hr>
     <H6 id="Dragon">Dragon</h6>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DragonLineage.png" align="middle"><b> Dragon Lineage</b></p>
-    <p><b>Cost</b>: 400 Dwarven and 400 Drow Royal Exchanges.</p>
+    <p><b>Cost</b>: 400 Dwarven and 400 Drow Royal Exchanges</p>
     <p><b>Effect</b>: Unique Buildings count as 12% more per level for all purposes.</p>
     <br/>
     <p><b>Level 5</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DragonPerk1.png" align="middle"><b> Dragon Perk 1</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Dragon Bloodline increases the production of Unique Buildings by 1.75% per building of the same type.</p>
     <br/>
     <p><b>Level 10</b></p>
@@ -589,9 +590,9 @@
     <br/>
     <p><b>Level 15</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DragonPerk2.png" align="middle"><b> Dragon Perk 2</b></p>
-    <p><b>Requirement</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirement</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Dragon Lineage Challenge.</p>
-    <p><b>Challenge</b>: 5 spells at Tier 5 in less than 10 minutes.</p>
+    <p><b>Challenge</b>: Have 5 spells at Tier 5 in less than 10 minutes.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Dragons Breath)</p>
     <br/>
     <p><b>Level 20</b></p>
@@ -599,17 +600,17 @@
     <p><b>Requirement</b>: Reach Lineage Level 20.</p>
     <p><b>Effect</b>: Maximum mana increased by 1.25 for every 2 Unique Buildings.</p>
     <br/>
-    <p><img src="http://musicfamily.org/realm/Factions/picks/DragonGrandChampionTrophy.png" align="middle"> <b>Dragon Grand Champion Trophy.</b></p>
+    <p><img src="http://musicfamily.org/realm/Factions/picks/DragonGrandChampionTrophy.png" align="middle"> <b>Dragon Grand Champion Trophy</b></p>
     <p><b>Requirement</b>: Upgrade Dragon Lineage to level 20 and purchase 3 Dragon Lineage perks.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><img src="http://musicfamily.org/realm/Factions/picks/DragonPerk4.png" align="middle"><b> Dragon Perk 4</b></p>
-    <p><b>Requirement</b>: A2+, Reach Lineage Level 30.</p>
+    <p><b>Requirement</b>: A2+, Reach Lineage Level 30</p>
     <p><b>Effect</b>: Activates two breaths per cast.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DragonPerk5.png" align="middle"> Dragon Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Lineage levels count 100% more.</p>
     <hr>
     <p><b>Elite Lineages - R130+</b></p>
@@ -622,34 +623,34 @@
     <br/>
     <p><b>Level 5</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonPerk1.png" align="middle"> Archon Perk 1</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: While using Archon Bloodline, increase production of Elite Unique Buildings based on maximum mana.</p>
     <p><b>Formula</b>: (0.8 * x ^ 0.8), where x is maximum mana.</p>
     <br/>
     <p><b>Level 10</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 10.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 10</p>
     <p><b>Effect</b>: x50 more Angel and Undead Faction Coin find chance.</p>
     <br/>
     <p><b>Level 15</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonPerk2.png" align="middle"> Archon Perk 2</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Archon Lineage Challenge.</p>
-    <p><b>Challenge</b>: Have at least 30B (3e10) mana regeneration within 45 seconds of a new run.</p>
+    <p><b>Challenge</b>: Have at least 30 billion (3e10) mana regeneration within 45 seconds of a new run.</p>
     <p><b>Effect</b>: Unlocks Faction spell. (Precognition).</p>
     <br/>
     <p><b>Level 20</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonPerk3.png" align="middle"> Archon Perk 3</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 20.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 20</p>
     <p><b>Effect</b>: Increase mana regeneration by 3% per 1000 Unique Buildings.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonPerk4.png" align="middle"> Archon Perk 4</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 30.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 30</p>
     <p><b>Effect</b>: Precognition also effects trophies, gems owned and faction coins found.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/ArchonPerk5.png" align="middle"> Archon Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Unique Buildings count 100% more.</p>
     <hr>
     <H6 id="Djinn">Djinn</h6>
@@ -660,34 +661,34 @@
     <br/>
     <p><b>Level 5</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnPerk1.png" align="middle"> Djinn Perk 1</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 5.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: Catalyst casts in this game also increase Limited Wish counter for the purpose of increasing its bonus.</p>
     <p><b>Effect</b>: All spells cost 25% less.</p>
     <br/>
     <p><b>Level 10</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 10.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 10</p>
     <p><b>Effect</b>: x50 more Fairy and Demon Faction Coin find chance.</p>
     <br/>
     <p><b>Level 15</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnPerk2.png" align="middle"> Djinn Perk 2</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Djinn Lineage Challenge.</p>
-    <p><b>Challenge</b>: Have at least 1B (1e9) assistants within 45 seconds of a new run.</p>
-    <p><b>Effect</b>: Unlocks Faction spell. (Limited Wish).</p>
+    <p><b>Challenge</b>: Have at least 1 billion (1e9) assistants within 45 seconds of a new run.</p>
+    <p><b>Effect</b>: Unlocks Faction spell. (Limited Wish)</p>
     <br/>
     <p><b>Level 20</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnPerk3.png" align="middle"> Djinn Perk 3</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 20.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 20</p>
     <p><b>Effect</b>: Activity time for all spells counts 2.5% more for every 1000 Unique Buildings.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnPerk4.png" align="middle"> Djinn Perk 4</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 30.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 30</p>
     <p><b>Effect</b>: When Limited Wish is cast, gain +888 to automatic clicks stat.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/DjinnPerk5.png" align="middle"> Djinn Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Mana regeneration counts 200% more.</p>
     <hr>
     <H6 id="Makers">Makers</h6>
@@ -697,33 +698,34 @@
     <p><b>Effect</b>: Increase Royal Exchange bonus by multiplicative 8% per level.</p>
     <br/>
     <p><b>Level 5</b></p>
-    <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk1.png" align="middle"> Makers Perk 1</b></p>>
-    <p><b>Requirements</b>: Reach Lineage Level 5.</p>
+    <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk1.png" align="middle"> Makers Perk 1</b></p>
+    <p><b>Requirements</b>: Reach Lineage Level 5</p>
     <p><b>Effect</b>: While using Makers Bloodline, the requirement for Free Excavation Reset is reduced by 25%.</p>
     <br/>
     <p><b>Level 10</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 10.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 10</p>
     <p><b>Effect</b>: x50 more Elven and Goblin Faction Coin find chance.</p>
     <br/>
     <p><b>Level 15</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk2.png" align="middle"> Makers Perk 2</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 15.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 15</p>
     <p><b>Effect</b>: Unlocks Makers Lineage Challenge.</p>
-    <p><b>Challenge</b>: Have atleast 350000 buildings within 45 seconds of a new run.</p>
-    <p><b>Effect</b>: Unlocks Faction spell. (Infinite Spiral).</p>
+    <p><b>Challenge</b>: Have at least 350000 buildings within 45 seconds of a new run.</p>
+    <p><b>Effect</b>: Unlocks Faction spell. (Infinite Spiral)</p>
     <br/>
     <p><b>Level 20</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk3.png" align="middle"> Makers Perk 3</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 20.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 20</p>
     <p><b>Effect</b>: Increase Offline bonus by 10% per 500 Unique Buildings.</p>
     <br/>
     <p><b>Level 30</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk4.png" align="middle"> Makers Perk 4</b></p>
-    <p><b>Requirements</b>: Reach Lineage Level 30.</p>
-    <p><b>Effect</b>: While infinite spiral is active, production of all buildings increases by 1% each second, up to its maximum duration.</p>
+    <p><b>Requirements</b>: Reach Lineage Level 30</p>
+    <p><b>Effect</b>: While Infinite Spiral is active, the production of all buildings increases by 1% each second, up to its maximum duration.</p>
     <br/>
-    <p><b>level 45</b></p>
+    <p><b>Level 45</b></p>
     <p><b><img src="http://musicfamily.org/realm/Factions/picks/MakersLineagePerk5.png" align="middle"> Makers Perk 5</b></p>
-    <p><b>Requirements</b>: R130, Lineage Level 45.</p>
+    <p><b>Requirements</b>: R130, Lineage Level 45</p>
     <p><b>Effect</b>: Excavations count 200% more.</p>
+    <br/>
         <?php include "../scripts/footer.html"; ?>


### PR DESCRIPTION
Fixes a lot of grammar errors, missing capitalizations, and also necessitated break tags between Titan base effect and perk 1 (and end of Makers perk 5), otherwise the bot would continue indexing until the next effect (or none at all and throwing an error). Also removed a really lot of periods, they were unnecessary as titles. If there are issues, let me know.

Once the page is updated, I'll publish Lineage command as it's complete now.