### PR TITLE
Add A3 builds for 4.0

### DIFF
--- a/R160Plus/index.php
+++ b/R160Plus/index.php
@@ -4,388 +4,318 @@
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
 <?php include "../scripts/header.html"; ?>
 <h6><img src="http://musicfamily.org/realm/Factions/picks/TopPageResearch.png" alt="Spellcraft" align="middle"></h6>
-<p style="color:red"><b>All Builds are outdated as of v4.0. Use the <a target="_blank" href="https://discord.gg/cq6zmQX"><b>Realm Grinder Discord</a> for build testing and crafting.</b></p>
 <br/>
     <p><b>Production Builds</b></p>
     <div class="category">
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Demonline Goblin (R160-R170)</a></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Archonline Goblin (R160-R170)</a></b></p>
             <div class="autohide">
-                <p><b>Author</b>: kiluh</p>
-                <p><b>Range</b>: 0 - 1e45 (1 Qad) Gems</p>
+                <p><b>Author</b>: ?</p>
+                <p><b>Range</b>: 0 - 1e40? (10 Dd) Gems</p>
                 <p><b>Faction</b>: Goblin</p>
-                <p><b>Bloodline</b>: Demon</p>
+                <p><b>Bloodline</b>: Archon</p>
                 <p><b>Artifact Set</b>: Dwarf</p>
                 <p><b>Stoneheart Set</b>: Goblin</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="S30,S50,S200,S3200,C80,C105,C120,C135,C150,C175,C200,C250,C305,C330,C340,C400,C500,D200,D290,D330,D1275,D1375,E1,E135,E145,E200,E320,E400,E460,E495,E1325,A10,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A410,A545,W25,W135,W205,W400,W1275,W1375">
+                    <input type="text" value="S200,S30,S50,S105,S135,S150,S215,C80,C105,C120,C135,C150,C340,D55,D150,D200,D250,D290,E135,E145,E200,E250,E1,E30,E80,A120,A400,A10,A55,A105,A135,A150,W25,W135,W180,W205,W290,W150">
 				</p>
-                <p>S30,S50,S200,S3200,</p>
-                <p>C80,C105,C120,C135,C150,C175,C200,C250,C305,C330,C340,C400,C500,</p>
-                <p>D200,D290,D330,D1275,D1375,</p>
-                <p>E1,E135,E145,E200,E320,E400,E460,E495,E1325,</p>
-                <p>A10,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A410,A545,</p>
-                <p>W25,W135,W205,W400,W1275,W1375</p>
+                <p>S200,S30,S50,S105,S135,S150,S215,</p>
+                <p>C80,C105,C120,C135,C150,C340,</p>
+                <p>D55,D150,D200,D250,D290,</p>
+                <p>E135,E145,E200,E250,E1,E30,E80,</p>
+                <p>A120,A400,A10,A55,A105,A135,A150,</p>
+                <p>W25,W135,W180,W205,W290,W150</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">The Reunion (R171-R175)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Archonline Fairy (R167-R169)</a></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 0 - 1e60 (1 Nod) Gems</p>
-                <p><b>Requirements</b>: Mercenary Duel</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>Artifact Set</b>: Dwarf</p>
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Range</b>: 1e40 (10 Dd) Gems - 1e45 (1 Qad) Gems</p>
+                <p><b>Faction</b>: Fairy</p>
+                <p><b>Bloodline</b>: Archon</p>
+                <p><b>Artifact Set</b>: Dwarf (first run), Fairy (subsequent runs)</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN12,GB4,UD10,DM9,TT3,TT8,DD11,DN2,DW12,DG4,DJ3,DJ7,MK5,SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,S50,S135,S150,S200,S215,S250,S270,S330,S400,S1500,C25,C80,C120,C150,C175,C250,C340,C400,C590,C1300,D25,D55,D200,D275,D290,D1275,D1375,E1,E25,E30,E135,E3300,A10,A55,A105,A120,A250,A2950,W25,W135,W150,W175,W180,W205,W275,W400,W525,W1375">
+                    <input type="text" value="S200,S400,S180,C340,C250,C400,C105,D200,D290,D330,D205,E50,E135,E145,E320,E410,E290,A30,A120,A270,A305,A400,W1375">
 				</p>
-                <p>EL3,EL7,AN5,AN12,GB4,UD10,DM9,TT3,TT8,DD11,DN2,DW12,DG4,DJ3,DJ7,MK5,</p>
+                <p>S200,S400,S180,</p>
+                <p>C340,C250,C400,C105,</p>
+                <p>D200,D290,D330,D205,</p>
+                <p>E50,E135,E145,E320,E410,E290,</p>
+                <p>A30,A120,A270,A305,A400,</p>
+                <p>W1375</p>
+                <p><b>Additional</b>: S215,S330,S150,D525,E410,A250,A150,W180,W120,W150</p>
+                <p><b>Notes</b>: Relies on LW building up (see DJC1 reward) and boosting spell durations->max mana. Import template at the start and after that import when LW hits spell duration, as Archon bl is buffed. Don't reset Fairy Chanting (see DJC1 reward), instead import/export save to update FC duration (at least once lw hits spell duration)</p>
+                <p><i>For highest gain</i>: target maelstrom on HoL with assistants or faction coins <b>and</b> A low building tier (see DJC1 reward). Have catalyst on GG when LW: spell duration is running, and have DJC4 on maximum mana</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R170-180 Production</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Ensteffahn</p>
+                <p><b>Range</b>: 0 - 1e65 (100 Vg) Gems</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Archon</p>
+                <p><b>A2950</b>: Dragon</p>
+                <p><b>Artifact Set</b>: Demon</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL5,EL9,AN5,AN12,GB3,GB4,UD7,UD10,DM2,DD11,DN2,DW7,DW12,AR2,DJ5,DJ7,SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,S50,S135,S150,S200,S215,S330,S400,S460,S1500,S500,S180,C175,C250,C340,C400,C500,C590,C1325,C305,C330,C25,C105,D200,D275,D290,D320,D330,D1375,D560,D250,D150,D135,E3300,E135,E495,E145,E30,E25,E1,A2950,A30,A120,A270,A305,A545,A250,W135,W205,W275,W400,W1275,W1375,W175,W180">
+				</p>
+                <p>EL5,EL9,AN5,AN12,GB3,GB4,UD7,UD10,DM2,DD11,DN2,DW7,DW12,AR2,DJ5,DJ7,</p>
                 <p>SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,</p>
-                <p>S50,S135,S150,S200,S215,S250,S270,S330,S400,S1500,</p>
-                <p>C25,C80,C120,C150,C175,C250,C340,C400,C590,C1300,</p>
-                <p>D25,D55,D200,D275,D290,D1275,D1375,</p>
-                <p>E1,E25,E30,E135,E3300,</p>
-                <p>A10,A55,A105,A120,A250,A2950,</p>
-                <p>W25,W135,W150,W175,W180,W205,W275,W400,W525,W1375</p>
+                <p>S50,S135,S150,S200,S215,S330,S400,S460,S1500,S500,S180,</p>
+                <p>C175,C250,C340,C400,C500,C590,C1325,C305,C330,C25,C105,</p>
+                <p>D200,D275,D290,D320,D330,D1375,D560,D250,D150,D135,</p>
+                <p>E3300,E135,E495,E145,E30,E25,E1,</p>
+                <p>A2950,A30,A120,A270,A305,A545,A250,</p>
+                <p>W135,W205,W275,W400,W1275,W1375,W175,W180</p>
+                <p><b>Notes</b>: Get archonline before importing researches (Reimport frequently to unlock each research as Arcline grows)</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Forbidden Grounds (R175-R190)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R180-190 Production</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range (R175-R180)</b>: 0 - 1e70 (10 Dvg) Gems</p>
-				<p><b>Range (R181+)</b>: 0 - 1e50 (100 Qid) Gems </p>
-                <p><b>Requirements</b>: A3 Research Facility Artifacts</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Titan</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR2,EL3,EL7,EL11,AN5,AN8,AN12,GB4,GB7,TT10,DD6,DN2,DW12,DJ3,DJ7,MK6,SP:Grand Balance,SP:Infinite Spiral,UB:Mountain Palace,UNN:FR,S30,S200,S215,S400,S5125,C25,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D480,D590,D1275,D1375,E25,E30,E135,E145,E400,E5125,A30,A55,A105,A120,A135,A150,A175,A200,A250,A270,A305,A330,A375,A495,A2950,W25,W120,W275,W400,W5125">
-				</p>
-                <p>FR2,EL3,EL7,EL11,AN5,AN8,AN12,GB4,GB7,TT10,DD6,DN2,DW12,DJ3,DJ7,MK6,</p>
-				<p>SP:Grand Balance,SP:Infinite Spiral,UB:Mountain Palace,UNN:FR,</p>
-                <p>S30,S200,S215,S400,S5125,</p>
-                <p>C25,C175,C250,C340,C5125,</p>
-                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D480,D590,D1275,D1375,</p>
-                <p>E25,E30,E135,E145,E400,E5125,</p>
-                <p>A30,A55,A105,A120,A135,A150,A175,A200,A250,A270,A305,A330,A375,A495,A2950,</p>
-                <p>W25,W120,W275,W400,W5125</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Artifactory (R181-R190)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Rellikrellik</p>
-                <p><b>Range</b>: 1e50 (100 Qid) - 1e75 (1 Qavg) Gems</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN12,GB4,GB7,TT3,TT10,FC7,DN2,DW12,DG5,AR2,AR5,AR10,DJ7,SP:Grand Balance,SP:Precognition,UB:Mountain Palace,UNN:DM,S5875,S200,S500,S330,S150,C175,C250,C340,C400,C5625,D5875,D200,D290,E135,E145,E290,E1325,E1425,E3300,A120,A270,A305,A1200,A1500,A2950,W175,W275,W400,W5125,W1275,F5500">
-				</p>
-                <p>EL3,EL7,AN5,AN12,GB4,GB7,TT3,TT10,FC7,DN2,DW12,DG5,AR2,AR5,AR10,DJ7,</p>
-				<p>SP:Grand Balance,SP:Precognition,UB:Mountain Palace,UNN:DM,</p>
-                <p>S5875,S200,S500,S330,S150,</p>
-                <p>C175,C250,C340,C400,C5625,</p>
-                <p>D5875,D200,D290,</p>
-                <p>E135,E145,E290,E1325,E1425,E3300,</p>
-                <p>A120,A270,A305,A1200,A1500,A2950,</p>
-                <p>W175,W275,W400,W5125,W1275,</p>
-                <p>F5500</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Eternal Tax (R182-R190)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e75 (1 Qavg) Gems+</p>
+                <p><b>Author</b>: Ensteffahn, modified by Kain, Regulus</p>
+                <p><b>Requirement</b>: R180 artifacts</p>
+                <p><b>Range</b>: ?</p>
                 <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
+                <p><b>Bloodline</b>: Archon</p>
                 <p><b>A2950</b>: Dragon</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Demon</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR10,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,S30,S50,S105,S400,S5875,C25,C80,C105,C120,C135,C150,C175,C200,C340,C5125,D5875,D25,D55,D200,D290,E1,E25,E30,E80,E135,E145,E150,E225,E230,E250,E275,E290,E320,E350,E495,E3300,A10,A55,A105,A120,A135,A150,A175,A200,A250,A300,A305,A330,A375,A410,A545,A2950,W25,W150,W275,W400,W525,W5125,F5500">
+                    <input type="text" value="EL9,AN4,AN5,AN12,GB3,GB6,UD7,UD10,FC3,DD11,DN2,DW7,DW12,AR2,DJ5,DJ7,SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,S200,S50,S135,S150,S400,S330,S215,S250,S180,S30,S105,C5125,C340,C400,C175,C250,C590,C25,C105,C150,D1375,D2775,D275,D290,D200,D330,D590,D320,D55,D135,D150,D25,D245,D250,E3300,E1225,E230,E135,E320,E290,E1,E25,E30,E145,E400,E460,E495,A1500,A2950,A30,A120,A410,A545,A10,A105,A150,A250,A270,A305,A375,A55,W5125,W275,W400,W205,W25,W135,W150,W180,W250,W175,W120,F5750">
 				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR10,DJ3,DJ5,DJ7,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,</p>
-                <p>S30,S50,S105,S400,S5875,</p>
-                <p>C25,C80,C105,C120,C135,C150,C175,C200,C340,C5125,</p>
-                <p>D5875,D25,D55,D200,D290,</p>
-                <p>E1,E25,E30,E80,E135,E145,E150,E225,E230,E250,E275,E290,E320,E350,E495,E3300,</p>
-                <p>A10,A55,A105,A120,A135,A150,A175,A200,A250,A300,A305,A330,A375,A410,A545,A2950,</p>
-                <p>W25,W150,W275,W400,W525,W5125,</p>
-                <p>F5500</p>
-				<p><b>Notes</b>: Benefits from buffing assistants and spell casts.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Order of Knowledge (R190-R206)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 0 Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 1</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p><b>MCC4 Union (R202+)</b>: Archon</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,GB7,TT3,TT10,FC7,DN2,DW12,DG5,AR2,AR5,AR10,DJ7,SP:Grand Balance,SP:Precognition,UB:Mountain Palace,UNN:DM,S5875,S500,S200,S330,C5625,C175,C250,C340,C590,D200,D290,D1375,D5125,E3300,E1425,E135,E145,E230,E290,E1325,A120,A270,A305,A1200,A1500,A2950,W175,W275,W400,W5125,F5500">
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,GB7,TT3,TT10,FC7,DN2,DW12,DG5,AR2,AR5,AR10,DJ7,SP:Grand Balance,SP:Precognition,UB:Mountain Palace,UNN:DM,UNN:AR,S5875,S500,S200,S330,C5625,C175,C250,C340,C590,D200,D290,D1375,D5125,E3300,E1425,E135,E145,E230,E290,E1325,A120,A270,A305,A1200,A1500,A2950,W175,W275,W400,W5125,F5500">
-					<b>MCC4 completed (R202+)</b>
-				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,GB7,TT3,TT10,FC7,DN2,DW12,DG5,AR2,AR5,AR10,DJ7,</p>
-                <p>SP:Grand Balance,SP:Precognition,UB:Mountain Palace,UNN:DM,</p>
-                <p>S5875,S500,S200,S330,</p>
-                <p>C5625,C175,C250,C340,C590,</p>
-                <p>D200,D290,D1375,D5125,</p>
-                <p>E3300,E1425,E135,E145,E230,E290,E1325,</p>
-                <p>A120,A270,A305,A1200,A1500,A2950,</p>
-                <p>W175,W275,W400,W5125,</p>
-                <p>F5500</p>
-				<p><b>Notes</b>: Benefits from buffing assistants and mana produced.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Chaos of Khorne (R194-R198)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e90 (1 Novg) Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 2</p>
-                <p><b>Faction</b>: Evil/Chaos Mercenary</p>
-                <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Goblin</p>
-				<p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Faceless</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL11,AN5,AN8,GB4,GB7,UD10,DM9,TT3,DD6,DN2,DW12,AR12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DN,S200,S400,S5875,C5125,C175,C250,C340,C400,C590,D5875,D200,D275,D290,D330,E135,E230,E290,E320,E5125,A30,A250,A270,A305,A545,A2950,W1275,W5125,W275,W400,W525,W205,F5500">
-				</p>
-                <p>EL3,EL11,AN5,AN8,GB4,GB7,UD10,DM9,TT3,DD6,DN2,DW12,AR12,DJ3,DJ5,DJ7,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DN,</p>
-                <p>S200,S400,S5875,</p>
-                <p>C5125,C175,C250,C340,C400,C590,</p>
-                <p>D5875,D200,D275,D290,D330,</p>
-                <p>E135,E230,E290,E320,E5125,</p>
-                <p>A30,A250,A270,A305,A545,A2950,</p>
-                <p>W1275,W5125,W275,W400,W525,W205,</p>
-                <p>F5500</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
-				<p><b>Notes</b>: Use remaining research point budget to buff DJ3.</p>
-				<p><b>Notes</b>: For setup, recast Fairy Chanting when Chaos Madness: Faceless Lineage is active.</p>
-				<p><b>Notes</b>: For production, target Maelstrom at Hall of Legends with Assistants effect and Chaos Madness on Dragon Lineage.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Descent into Madness (R198-R206)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e90 (1 Novg) Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 3</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
-                <p><b>A2950</b>: Elf</p>
-				<p><b>A2950 (1 hour+ run)</b>: Makers</p>
-				<p><b>D5875 (below 1 hour runs)</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p><b>MCC4 Union (R202+)</b>: Makers</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D5875,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D200,D275,D290,D5125,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-					<b>1 hour+ run</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D5875,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-					<b>MCC4 completed (R202+)</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D200,D275,D290,D5125,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-					<b>MCC4 completed (R202+), 1 hour+ run</b>
-				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,</p>
-                <p>S30,S50,S330,S400,S5125,</p>
-                <p>C25,C80,C175,C250,C340,C5125,</p>
-                <p>D25,D55,D5875,</p>
-                <p>E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,</p>
-                <p>A10,A105,A150,A175,A250,A305,A545,A1500,A2950,</p>
-                <p>W25,W275,W525,W5125,</p>
+                <p>EL9,AN4,AN5,AN12,GB3,GB6,UD7,UD10,FC3,DD11,DN2,DW7,DW12,AR2,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,</p>
+                <p>S5125,S200,S50,S135,S150,S400,S330,S215,S250,S180,S30,S105,</p>
+                <p>C5125,C340,C400,C175,C250,C590,C25,C105,C150,</p>
+                <p>D1375,D2775,D275,D290,D200,D330,D590,D320,D55,D135,D150,D25,D245,D250,</p>
+                <p>E3300,E1225,E230,E135,E320,E290,E1,E25,E30,E145,E400,E460,E495,</p>
+                <p>A1500,A2950,A30,A120,A410,A545,A10,A105,A150,A250,A270,A305,A375,A55,</p>
+                <p>W5125,W275,W400,W205,W25,W135,W150,W180,W250,W175,W120,</p>
                 <p>F5750</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
-				<p><b>Notes</b>: Swap A2950 Elf with Makers and D5875 with D200,D275,D290,D5125 at 1 hour+ runs.</p>
+                <p><b>Notes</b>: Swap DN2->DM2, once 1h+ evil time this R. Faster than Short Burn to 190 probably</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">World's Edge (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Long Spells Short Burn (R180-R190)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 0 - 1e105 (1 Novg) Gems</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
+                <p><b>Author</b>: Rade</p>
+                <p><b>Range</b>: ?</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Fairy</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN5,GB3,GB4,GB6,UD7,UD10,DM2,DD10,FC3,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,SP:Hellfire Blast,SP:Precognition,UB:Brothel,UNN:DW,S30,S50,S135,S180,S200,S215,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D480,D590,D1275,D1375,E1,E25,E30,E80,E135,E145,E230,E320,E495,E1225,E3300,A10,A25,A30,A55,A120,A135,A150,A175,A250,A270,A305,A1500,A2950,W25,W175,W275,W400,W5125,F5750">
+				</p>
+                <p>AN5,GB3,GB4,GB6,UD7,UD10,DM2,DD10,FC3,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Hellfire Blast,SP:Precognition,UB:Brothel,UNN:DW,</p>
+                <p>S30,S50,S135,S180,S200,S215,S5125,</p>
+                <p>C25,C80,C175,C250,C340,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D480,D590,D1275,D1375,</p>
+                <p>E1,E25,E30,E80,E135,E145,E230,E320,E495,E1225,E3300,</p>
+                <p>A10,A25,A30,A55,A120,A135,A150,A175,A250,A270,A305,A1500,A2950,</p>
+                <p>W25,W175,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: This build is only stronger than R180-R190 production if buffed high enough, which likely requires more time than simply continuing to push with the other build. <b>Requires buffing fairy time (15+ minutes) and buffing max ziggurat count and max flesh workshop count</b> (can swap UB to this for during early runs) to non-zero values; reset fairy chanting and precognition periodically to update effects that benefit from spell duration. Grand Balance will eventually outperform hellfire blast if you produce enough mana in the reincarnation, not sure exactly when (7e17 mana this R?). If FC3 is low, it can be swapped out for DN2.If using shorter fairy buff times, experimenting with different sets may produce a better result.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">DPE (Diabolic Penguin Empire) (R190-R198)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Meirlu</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Range</b>: 1e80 (100 Qivg) Gems - 1e105 (1 Qatg) Gems </p>
                 <p><b>Faction</b>: Evil/Order Mercenary</p>
                 <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Faceless </p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>MCC4</b>: Angel</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
-				<p>
+                <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL4,AN5,AN8,GB4,GB7,UD10,DM9,TT3,DD11,FC11,DN2,AR2,AR12,DJ5,DJ7,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:DM,UNN:AR,S200,S400,S5875,C5125,C175,C250,C340,C400,C590,D200,D275,D290,D330,D1375,D3350,E5125,E135,E145,E230,E290,E320,E495,E3300,A30,A120,A270,A2950,A5375,W1275,W5625,W175,W180,W205,W275,W400,W525,F5250">
+                    <input type="text" value="GB3,AN4,AN5,AN8,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,SP:Grand Balance,SP:Precognition,UB:Brothel,UNN:AR,S200,S400,S5875,S180,C5125,C175,C250,C340,C400,D200,D275,D290,D330,D1375,D5625,E3300,E135,E5125,E400,E495,E145,E230,A2950,A270,A5375,W5625,W1275,W275,W400,W1375,W205,F5250">
 				</p>
-                <p>EL3,EL4,AN5,AN8,GB4,GB7,UD10,DM9,TT3,DD11,FC11,DN2,AR2,AR12,DJ5,DJ7,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:DM,UNN:AR,</p>
-                <p>S200,S400,S5875,</p>
-                <p>C5125,C175,C250,C340,C400,C590,</p>
-                <p>D200,D275,D290,D330,D1375,D3350,</p>
-                <p>E5125,E135,E145,E230,E290,E320,E495,E3300,</p>
-                <p>A30,A120,A270,A2950,A5375,</p>
-                <p>W1275,W5625,W175,W180,W205,W275,W400,W525,</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="A30,A120,A250,A305">
+                    <b>After A5375</b>
+                </p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="S150,S215,S330,S460,S590,S545,S305,S30,C1300,C500,C590,C25,C105,D25,D150,D320,E290,E1225,E10,E320,E460,E480,E1325,W120,W150,W25,W180">
+                    <b>After alchemy Boosts and W1375</b>
+                </p>
+                <p>GB3,AN4,AN5,AN8,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Brothel,UNN:AR,</p>
+                <p>S200,S400,S5875,S180,</p>
+                <p>C5125,C175,C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,D5625,</p>
+                <p>E3300,E135,E5125,E400,E495,E145,E230,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W5625,W1275,W275,W400,W1375,W205,</p>
                 <p>F5250</p>
-				<p><b>Notes</b>: <b>Reverse autocast Precognition, Dragon's Breath, Fairy Chanting as their duration increases.</b></p>
-				<p><b>Notes</b>: Benefits from buffing S400.</p>
+                <p><b>After A5375</b>:</p>
+                <p>A30,A120,A250,A305</p>
+                <p><b>After alchemy boosts and W1375</b>:</p>
+                <p>S150,S215,S330,S460,S590,S545,S305,S30,</p>
+                <p>C1300,C500,C590,C25,C105,</p>
+                <p>D25,D150,D320,</p>
+                <p>E290,E1225,E10,E320,E460,E480,E1325,</p>
+                <p>W120,W150,W25,W180</p>
+                <p><b>Notes</b>: Switch DN2->DM2 when going for A5375. Buff f6000, max ziggurats, max flesh workshops, mana produced, assistants. Requires approximately 46.5 hours to be able to afford a5375 of time this game (with Chrono Loading added). For reference, with faceless lineage at 66 at 191, this would require approximately 15h F6000 and 900% DD10 bonus, which can be achieved with roughly 40k ziggurats and switching DN2 for DM2 with a 250% value. Can switch Brothel and Flesh Workshops to buff workshops</p>
+                <p><b>Notes</b>: At r202+ use angel union to buff highest mana regeneration more. This build requires recasting spells occasionally, especially fairy chanting and precognition.</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Infinite Insanity Machine (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Lazier DPE (R190-R198)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e105 (1 Novg) - 1e133 (10 Tqag) Gems</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
-                <p><b>A2950</b>: Dragon</p>
-				<p><b>D5875</b>: Makers</p>
+                <p><b>Author</b>: Rade, based on Meirlu's DPE</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Range</b>: 0 - 1e85 (10 Spvg) Gems </p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Faceless</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
-				<p>
+                <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,FC7,DN2,DW6,DW12,AR3,AR10,DJ7,MK6,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,UNN:MK,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D5875,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,FC7,DN2,DW6,DW12,AR3,AR10,DJ7,MK6,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,UNN:MK,</p>
-                <p>S30,S50,S330,S400,S5125,</p>
-                <p>C25,C80,C175,C250,C340,C5125,</p>
-                <p>D25,D55,D5875,</p>
-                <p>E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,</p>
-                <p>A10,A105,A150,A175,A250,A305,A545,A1500,A2950,</p>
-                <p>W25,W275,W525,W5125,</p>
-                <p>F5750</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
+                    <input type="text" value="GB3,AN4,AN5,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,DW7,AR2,AR12,DJ5,DJ7,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:AR,S200,S400,S5875,C5125,C175,C250,C340,C400,D200,D275,D290,D330,D1375,D1275,E3300,E135,E5125,E495,E145,E230,A2950,A270,A30,A120,A250,A305,A1500,W1275,W5625,W275,W400,W205,F5250">
+                    <b>Variant 1 (requires ziggurat buff, slightly stronger)</b>
+                </p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="S150,S215,S330,S460,S305,S590,S545,S305,C1300,C590,D25,D320,D55,D3350,D150,E290,E1225,E10,E320,E480,E1325,A590,A545,A410,A150,A105,A55,W120,W150,W25,W180">
+                    <b>Variant 1 secondary researches</b>
+                </p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN5,GB3,GB4,GB6,UD7,UD10,FC3,DD11,DN2,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:AR,S200,S400,S5875,S180,C5125,C175,C250,C340,C400,D200,D275,D290,D330,D1375,E3300,E135,E400,E495,E145,E230,A2950,A270,A30,A120,A250,A305,W1275,W5625,W275,W400,F5250">
+                    <b>Variant 2(no ziggurat buff needed, slightly weaker)</b>
+                </p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="S150,S215,S330,S460,S590,S545,S305,S30,C590,C80,C135,C150,C25,C105,C305,D25,D150,D320,D55,D135,D245,D250,D480,D560,D590,D1275,D400,E290,E1225,E10,E320,E460,E480,E1325,E25,E30,E80,A1,A55,A105,A135,A150,A175,A375,A545,A495,A590,A480,A330,A300,W25,W50">
+                    <b>Variant 2 secondary researches</b>
+                </p>
+                <p><b>Variant 1 (requires ziggurat buff, slightly stronger)</b>:</p>
+                <p>GB3,AN4,AN5,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,DW7,AR2,AR12,DJ5,DJ7,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:AR,</p>
+                <p>S200,S400,S5875,</p>
+                <p>C5125,C175,C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,D1275,</p>
+                <p>E3300,E135,E5125,E495,E145,E230,</p>
+                <p>A2950,A270,A30,A120,A250,A305,A1500,</p>
+                <p>W1275,W5625,W275,W400,W205,</p>
+                <p>F5250</p>
+                <p><b>Variant 1 secondary researches</b>:</p>
+                <p>S150,S215,S330,S460,S305,S590,S545,S305,</p>
+                <p>C1300,C590,</p>
+                <p>D25,D320,D55,D3350,D150,</p>
+                <p>E290,E1225,E10,E320,E480,E1325,</p>
+                <p>A590,A545,A410,A150,A105,A55,</p>
+                <p>W120,W150,W25,W180,</p>
+                <p><b>Variant 2(no ziggurat buff needed, slightly weaker)</b>:</p>
+                <p>AN5,GB3,GB4,GB6,UD7,UD10,FC3,DD11,DN2,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:AR,</p>
+                <p>S200,S400,S5875,S180,</p>
+                <p>C5125,C175,C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,</p>
+                <p>E3300,E135,E400,E495,E145,E230,</p>
+                <p>A2950,A270,A30,A120,A250,A305,</p>
+                <p>W1275,W5625,W275,W400,</p>
+                <p>F5250</p>
+                <p><b>Variant 2 secondary researches</b>:</p>
+                <p>S150,S215,S330,S460,S590,S545,S305,S30,</p>
+                <p>C590,C80,C135,C150,C25,C105,C305,</p>
+                <p>D25,D150,D320,D55,D135,D245,D250,D480,D560,D590,D1275,D400,</p>
+                <p>E290,E1225,E10,E320,E460,E480,E1325,E25,E30,E80,</p>
+                <p>A1,A55,A105,A135,A150,A175,A375,A545,A495,A590,A480,A330,A300,</p>
+                <p>W25,W50</p>
+                <p><b>Notes</b>: Doesn’t require F6000 buffing, good for earlier ranges and easier to start with limited buffs to game time. Benefits from mana produced/spells cast this R. Import the primary template repeatedly as you earn more points until all researches listed have been picked (usually W5625 is the last one to get selected), then repeatedly import secondary researches. Wait for catalyst to hit gem grinder for maximum production before abdicating. As with other builds, reset all spells periodically to increase their duration and buff effects, especially fairy chanting and precognition.</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Into the Void (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Final Verdict (R198+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e133 (10 Tqag) Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5, at least 2d 16h this game (F6000 included)</p>
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Requirement</b>: MCC3</p>
+                <p><b>Range</b>: ?</p>
                 <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
+                <p><b>Bloodline</b>: Fairy</p>
                 <p><b>A2950</b>: Makers</p>
-				<p><b>D5875</b>: Archon</p>
+                <p><b>MCC4</b>: Makers</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
-				<p>
+                <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD7,UD10,DM9,TT3,DN2,DW6,DW12,AR3,AR10,DJ7,MK6,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,S50,S400,S1500,S5875,C250,C340,C400,C590,C5125,D5875,D200,D275,D290,D1375,E400,E3300,E5125,A2950,A5875,W150,W180,W205,W275,W400,W525,W1400,W5125,F5750">
+                    <input type="text" value="EL5,GB3,GB4,GB6,UD7,UD10,FC3,DN2,EL9,DW7,EL12,DW12,AR12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,UNN:MK,S30,S180,S200,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,E25,E135,E145,E230,E320,E5125,A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,W25,W175,W275,W400,W5125,F5750">
 				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,UD7,UD10,DM9,TT3,DN2,DW6,DW12,AR3,AR10,DJ7,MK6,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,</p>
-                <p>S50,S400,S1500,S5875,</p>
-                <p>C250,C340,C400,C590,C5125,</p>
-                <p>D5875,D200,D275,D290,D1375,</p>
-                <p>E400,E3300,E5125,</p>
-                <p>A2950,A5875,</p>
-                <p>W150,W180,W205,W275,W400,W525,W1400,W5125,</p>
+                <p>EL5,GB3,GB4,GB6,UD7,UD10,FC3,DN2,EL9,DW7,EL12,DW12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DG,UNN:MK,</p>
+                <p>S30,S180,S200,S400,S5125,</p>
+                <p>C25,C80,C175,C250,C340,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,</p>
+                <p>E25,E135,E145,E230,E320,E5125,</p>
+                <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
+                <p>W25,W175,W275,W400,W5125,</p>
                 <p>F5750</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
-            </div>
-        </div>
-    </div>
-    <br/>
-    <p><b>Mercenary Duel Unlock</b></p>
-    <p>Tested at end of R170 with 1e45 (1 Qad) Gems</p>
-    <div class="category">
-	    <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Demonline Goblin (Spell casts)</a></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: kiluh</p>
-                <p><b>Range</b>: 1e45 (1 Qad) Gems+</p>
-                <p><b>Faction</b>: Goblin</p>
-                <p><b>Bloodline</b>: Demon</p>
-                <p><b>Artifact Set</b>: Dwarf</p>
-                <p><b>Stoneheart Set</b>: Goblin</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="S30,S50,S200,S3200,C80,C105,C120,C135,C150,C175,C200,C250,C305,C330,C340,C400,C500,D200,D290,D330,D1275,D1375,E1,E135,E145,E200,E320,E400,E460,E495,E1325,A10,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A410,A545,W25,W135,W205,W400,W1275,W1375">
-				</p>
-                <p>S30,S50,S200,S3200,</p>
-                <p>C80,C105,C120,C135,C150,C175,C200,C250,C305,C330,C340,C400,C500,</p>
-                <p>D200,D290,D330,D1275,D1375,</p>
-                <p>E1,E135,E145,E200,E320,E400,E460,E495,E1325,</p>
-                <p>A10,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A410,A545,</p>
-                <p>W25,W135,W205,W400,W1275,W1375</p>
-                <p><b>Note</b>: Estimated time: 5-7 hours</p>
+                <p><b>Notes</b>: Buff Fairyset (1-2h+), mana produced, assistants,f6000 (once progress slows down), max workshops, highest mana regen, excavations this R. At higher gems (~e50/60), use Brothel instead of Flesh Workshop. Reset spells often</p>
             </div>
         </div>
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Elfline Druids (Clicks and Faction Coins)</a></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Benevolent Warchant (R206+)</a></b><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: 7636kei</p>
-                <p><b>Range</b>: 1e45 (1 Qad) Gems+</p>
-                <p><b>Faction</b>: Druid</p>
-                <p><b>Bloodline</b>: Elf</p>
-                <p><b>Artifact Set</b>: Faceless</p>
-                <p><b>Stoneheart Set</b>: Elf</p>
+                <p><b>Author</b>: Regulus, modified by woopemgood</p>
+                <p><b>Requirement</b>: MCC5</p>
+                <p><b>Range</b>: 0 - A gems</p>
+                <p><b>Faction</b>: Good/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="S30,S105,S135,S150,S200,S215,S330,S400,S500,S1275,C105,C120,C135,C150,C250,C340,C400,C500,C1325,D55,D150,D200,D245,D250,D275,D290,D320,D330,D1375,E30,E135,E145,E250,E290,E320,E400,E460,E1425,A105,A120,A250,A270,A305,A400,A545,A1500,W135,W150,W400,W1375,W1400">
+                    <input type="text" value="AN4,AN5,GB3,DD6,UD10,FC3,DN2,UD7,DW7,DW8,DW10,DW12,AR2,AR11,DJ7,MK6,SP:Grand Balance,SP:Precognition,UB:Swarming Tower,UNN:DG,UNN:DW,S30,S150,S180,S200,S215,S330,S400,S1275,S3200,C25,C105,C340,C400,C5125,D25,D55,D135,D150,D200,D205,D250,D275,D290,D320,D330,D525,D560,D1275,D1375,E135,E320,E400,E5125,A30,A105,A120,A150,A270,A305,A545,A1500,A2950,W180,W275,W400,W5125,F5750">
 				</p>
-                <p>S30,S105,S135,S150,S200,S215,S330,S400,S500,S1275,</p>
-                <p>C105,C120,C135,C150,C250,C340,C400,C500,C1325,</p>
-				<p>D55,D150,D200,D245,D250,D275,D290,D320,D330,D1375,</p>
-                <p>E30,E135,E145,E250,E290,E320,E400,E460,E1425,</p>
-                <p>A105,A120,A250,A270,A305,A400,A545,A1500,</p>
-                <p>W135,W150,W400,W1375,W1400</p>
-                <p><b>Notes</b>: Estimated time: 18-20 hours, remember to buff Infinite Spiral during the run (6-10 Excavation Resets)</p>
+                <p>AN4,AN5,GB3,DD6,UD10,FC3,DN2,UD7,DW7,DW8,DW10,DW12,AR2,AR11,DJ7,MK6,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Swarming Tower,UNN:DG,UNN:DW,</p>
+                <p>S30,S150,S180,S200,S215,S330,S400,S1275,S3200,</p>
+                <p>C25,C105,C340,C400,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D205,D250,D275,D290,D320,D330,D525,D560,D1275,D1375,</p>
+                <p>E135,E320,E400,E5125,</p>
+                <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
+                <p>W180,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: Rush build up to ? gems. Swap e5125+e320->e5375, when going for a 20-30+ min run (gems?). Benefits from buffing: F6000,Fairy time (2-12+ hours increasing a bit every R), Max Flesh Workshops, Max Brothels, assistants, mana produced. Recast Fairy Chanting periodically. Remember to max Call to Arms tiers. (Swap DN2 with DM2 with ? hours as Evil.) ? (15hrs as evil doesn’t seem to be enough) Works for production until  A gems(?), after it slows down, maybe use high production build?</p>
             </div>
         </div>
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Makersline Fairy (Assistants, Buildings)</a></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R215(?)+ High Production</a></b><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Weedheter</p>
-                <p><b>Range</b>: 1e45 (1 Qad) Gems+</p>
-				<p><b>Requirements</b>: 1e7 (10 M) clicks, 1e18 (1 Qi) spells cast</p>
-                <p><b>Faction</b>: Fairy</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>Artifact Set</b>: Dwarf</p>
+                <p><b>Author</b>: PralEternal, Stoic79</p>
+                <p><b>Requirement</b>: MCC5</p>
+                <p><b>Range</b>: 1e140 (100 Qiqag) Gems +</p>
+                <p><b>Faction</b>: Good/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="S180,S200,S400,S1,S30,S105,S135,S150,S215,S250,S270,S330,S460,S500,C250,C340,C400,C520,C10,C105,C500,C1325,D290,D330,D1375,D200,D55,D135,D150,D205,D225,D245,D250,E50,E135,E145,E290,E320,E400,E460,E1325,E30,E330,A30,A120,A270,A305,A400,A545,A55,A105,A135,A150,A200,A250,A330,A480,W180,W400,W1275,W1375,W250">
+                    <input type="text" value="AN4,AN5,UD10,DM2,DD10,FC3,DN2,DN9,DW6,DW7,DW8,DW12,AR11,DJ3,DJ7,MK6,SP:Grand Balance,SP:Infinite Spiral,UB:Swarming Tower,UNN:DG,UNN:DW,S30,S150,S180,S200,S215,S250,S330,S400,S1275,S2875,C135,C340,C400,C5125,D25,D55,D200,D205,D275,D290,D320,D330,D480,D525,D590,D1275,D1375,E25,E30,E135,E400,E5375,A30,A150,A250,A270,A305,A545,A1500,A2950,W180,W275,W400,W5125,F5750">
 				</p>
-                  <p>S180,S200,S400,S1,S30,S105,S135,S150,S215,S250,S270,S330,S460,S500,</p>
-                  <p>C250,C340,C400,C520,C10,C105,C500,C1325,</p>
-                  <p>D290,D330,D1375,D200,D55,D135,D150,D205,D225,D245,D250,</p>
-                  <p>E50,E135,E145,E290,E320,E400,E460,E1325,E30,E330,</p>
-                  <p>A30,A120,A270,A305,A400,A545,A55,A105,A135,A150,A200,A250,A330,A480,</p>
-                  <p>W180,W400,W1275,W1375,W250</p>
-                  <p><b>Notes</b>: Estimated time: 5-20 minutes.</p>
+                <p>AN4,AN5,UD10,DM2,DD10,FC3,DN2,DN9,DW6,DW7,DW8,DW12,AR11,DJ3,DJ7,MK6,</p>
+                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Swarming Tower,UNN:DG,UNN:DW,</p>
+                <p>S30,S150,S180,S200,S215,S250,S330,S400,S1275,S2875,</p>
+                <p>C135,C340,C400,C5125,</p>
+                <p>D25,D55,D200,D205,D275,D290,D320,D330,D480,D525,D590,D1275,D1375,</p>
+                <p>E25,E30,E135,E400,E5375,</p>
+                <p>A30,A150,A250,A270,A305,A545,A1500,A2950,</p>
+                <p>W180,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: Needs multiple days of f6000 I think, Buff fairy set (up to a day(?)),F6000,Max assistants (e40+(?)),Max. Flesh workshops and Ziggurats, excavs/resets.</p>
             </div>
         </div>
     </div>
@@ -393,825 +323,766 @@
     <p><b>Buff Builds</b></p>
     <div class="category">
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182-R206 Spell casts, Mana Produced</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Lightning Fairy Buff</a></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e60 (1 Nod) Gems+</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>D5875 (Until MCC1)</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p><b>MCC4 Union (R202+)</b>: Demon</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DW6,DW12,AR2,DJ5,DJ7,AR10,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5875,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,MK10,DJ5,DJ7,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5875,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>16 hours+ this R</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DW6,DW12,AR2,AR10,DJ5,DJ7,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5125,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC1</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,DJ5,DJ7,MK10,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5125,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC1, 16 hours+ this R</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,DJ5,DJ7,MK10,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5625,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC1, D5625 is buffed</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DW6,DW12,AR2,AR10,DJ5,DJ7,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5125,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC4</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,DJ5,DJ7,MK10,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5125,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC4, 16 hours+ this R</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,DJ5,DJ7,MK10,SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,C5625,C175,C340,C500,C250,C400,C590,D5625,D200,D275,D290,D330,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A120,A250,A270,A305,A545,A1500,A2950,W5625,W205,W275,W400,W1275,F5250">
-					<b>MCC4, D5625 is buffed</b>
-				</p>
-				<p>EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DW6,DW12,AR2,AR10,DJ5,DJ7,</p>
-				<p>SP:Brainwave,SP:Precognition,UB:Burning Abyss,UNN:AR,</p>
-				<p>S5875,S200,S400,S500,</p>
-				<p>C5625,C175,C340,C500,C250,C400,C590,</p>
-				<p>D5875,D200,D275,D290,D330,</p>
-				<p>E135,E145,E230,E290,E320,E400,E495,E1325,E3300,</p>
-				<p>A120,A250,A270,A305,A545,A1500,A2950,</p>
-				<p>W5625,W205,W275,W400,W1275,</p>
-				<p>F5250</p>
-				<p><b>Notes</b>: Use excavation resets to buff C5625.</p>
-				<p><b>Notes</b>: Buffing F6000 helps.</p>
-				<p><b>Notes</b>: Swap DW12 -> DN12 and AR10 -> MK10 if 16 hours+ were spent this Reincarnation.</p>
-				<p><b>Notes</b>: Swap D5875 with D5125 if Mercenary Challenge 1 is completed.</p>
-				<p><b>Notes</b>: Swap D5125 with D5625 if D5625 is buffed.</p>
-				<p><b>Notes</b>: Use remaining points to buff production.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Spell casts, Mana Produced</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
+                <p><b>Author</b>: ?</p>
                 <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
+                <p><b>Faction</b>: Fairy</p>
+                <p><b>Bloodline</b>: Titan</p>
+                <p><b>Artifact Set</b>: Dwarf Set (prod) / Elf set (clicks)</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,FC11,DN2,DW6,AR2,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,S180,C5625,C175,C250,C340,C400,D5125,D200,D275,D290,D330,D1375,E135,E145,E230,E290,E320,E495,E3300,E1325,A30,A120,A270,A2950,A250,A305,A545,A1500,W5625,W1275,W400,W175,W275,W205,W180,W525,F5250">
+                    <input type="text" value="S1,S30,S180,S215,S400,S5125,C10,C105,C340,C400,C5125,D55,D135,D150,D205,D225,D245,D250,D290,D320,D435,D480,D525,D1275,D1375,E30,E50,E80,E135,E145,E150,E200,E250,E290,E320,E330,E400,E410,E460,E480,E1325,A30,A55,A105,A120,A135,A150,A200,A250,A305,A330,A400,A480,A3400,W120,W135,W150,W180,W200,W250,W400,W1375,W3150,F6000">
 				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,FC11,DN2,DW6,AR2,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,S180,C5625,C175,C250,C340,C400,D5125,D200,D275,D290,D330,D1375,E135,E145,E230,E290,E320,E495,E3300,E1325,A5375,A270,A2950,A30,W5625,W1275,W400,W175,W275,W205,W180,W525,F5250">
-					<b>1 day this game (F6000 included)</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,DN2,DN12,DW6,AR2,DJ5,DJ7,MK10,SP:Fairy Chanting,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,S5875,S200,S400,S500,S180,C5625,C175,C250,C340,C400,D5125,D200,D275,D290,D330,D1375,E135,E145,E230,E290,E320,E495,E3300,E1325,A5375,A270,A2950,A30,W5625,W1275,W400,W175,W275,W205,W180,W525,F5250">
-					<b>Needs Testing: 5 days this R</b>
-				</p>
-				<p>EL3,EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD11,FC11,DN2,DW6,AR2,AR12,DJ5,DJ7,</p>
-				<p>SP:Fairy Chanting,SP:Precognition,UB:Burning Abyss,UNN:DM,UNN:AR,</p>
-				<p>S5875,S200,S400,S500,S180,</p>
-				<p>C5625,C175,C250,C340,C400,</p>
-				<p>D5125,D200,D275,D290,D330,D1375,</p>
-				<p>E135,E145,E230,E290,E320,E495,E3300,E1325,</p>
-				<p>A30,A120,A270,A2950,A250,A305,A545,A1500,</p>
-				<p>W5625,W1275,W400,W175,W275,W205,W180,W525,</p>
-				<p>F5250</p>
-				<p><b>Notes</b>: Use excavation resets to buff C5625.</p>
-				<p><b>Notes</b>: Buffing F6000 helps.</p>
-				<p><b>Notes</b>: Swap D5125 with D5625 if D5625 is buffed.</p>
-				<p><b>Notes</b>: Swap A30,A120,A270,A2950,A250,A305,A545,A1500 with A5375,A270,A2950,A30 with atleast 1 day this game (F6000 included).</p>
-				<p><b>Notes</b>: <b>Needs Testing</b> Swap FC11 and AR12 with DN12 and MK10 with 5 days this R.</p>
-            </div>
-        </div>
-		<br />
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182-R194 Max Assistants</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e66 (1 Uvg) Gems+</p>
-                <p><b>Faction</b>: Evil/Chaos Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,GB4,GB7,UD10,TT3,DD11,DN2,DW6,DW12,AR2,DJ5,DJ7,MK10,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DN,S5875,S200,S500,S400,S330,C5625,C175,C340,C250,C400,C590,D5875,D200,D290,D330,D275,E135,E145,E230,E290,E320,E460,E495,E3300,E1325,E400,A30,A120,A250,A270,A305,A545,A1500,A2950,W5625,W175,W205,W275,W400,W525,F5500">
-				</p>
-                <p>EL3,EL7,AN5,AN8,GB4,GB7,UD10,TT3,DD11,DN2,DW6,DW12,AR2,DJ5,DJ7,MK10,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DN,</p>
-                <p>S5875,S200,S500,S400,S330,</p>
-                <p>C5625,C175,C340,C250,C400,C590,</p>
-                <p>D5875,D200,D290,D330,D275,</p>
-                <p>E135,E145,E230,E290,E320,E460,E495,E3300,E1325,E400,</p>
-                <p>A30,A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W5625,W175,W205,W275,W400,W525,</p>
-                <p>F5500</p>
-                <p><b>Notes</b>: Buff spells cast, use excavation resets to buff C5625</p>
-				<p><b>Notes</b>: Recommended to buff F6000 before each run.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R194-R206 Max Assistants</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 2</p>
-                <p><b>Faction</b>: Evil/Chaos Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950 (Until MCC4)</b>: Djinn</p>
-				<p><b>A2950 (After MCC4)</b>: Dragon</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p><b>MCC4 Union (R202+)</b>: Demon</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,GB4,GB7,UD10,TT3,DD11,DN2,DW6,DW12,AR2,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DN,S5875,S200,S180,S500,S400,C5625,C175,C340,C250,C400,C590,D5875,D200,D290,D330,D275,E135,E145,E230,E290,E320,E460,E495,E3300,E1325,E400,A30,A120,A250,A270,A305,A545,A1500,A2950,W5625,W1275,W400,W275,W205,W175,F5500">
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN8,GB4,GB7,UD10,TT3,DD11,DN2,DW6,DW12,AR2,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DN,UNN:DM,S5875,S200,S180,S500,S400,C5625,C175,C340,C250,C400,C590,D5875,D200,D290,D330,D275,E135,E145,E230,E290,E320,E460,E495,E3300,E1325,E400,A30,A120,A250,A270,A305,A545,A1500,A2950,W5625,W1275,W400,W275,W205,W175,F5500">
-					<b>MCC4 completed (R202+)</b>
-				</p>
-                <p>EL3,EL7,AN5,AN8,GB4,GB7,UD10,TT3,DD11,DN2,DW6,DW12,AR2,AR12,DJ5,DJ7,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DN,</p>
-                <p>S5875,S200,S180,S500,S400,</p>
-                <p>C5625,C175,C340,C250,C400,C590,</p>
-                <p>D5875,D200,D290,D330,D275,</p>
-                <p>E135,E145,E230,E290,E320,E460,E495,E3300,E1325,E400,</p>
-                <p>A30,A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W5625,W1275,W400,W275,W205,W175,</p>
-                <p>F5500</p>
-                <p><b>Notes</b>: Buff spells cast, use excavation resets to buff C5625</p>
-				<p><b>Notes</b>: Recommended to buff F6000 before each run.</p>
-				<p><b>Notes</b>: For setup, recast Fairy Chanting and Precognition when Chaos Madness: Faceless Lineage is active.</p>
-				<p><b>Notes</b>: Target Catalyst at Gem Grinder and Chaos Madness at (Untill MCC4) Dragon lineage / (After MCC4) Djinn or Undead Lineage for maximum benefits.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Max Assistants</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Undead</p>
-                <p><b>A2950</b>: Elf</p>
-                <p><b>D5875</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL4,EL7,EL12,AN5,AN12,GB4,GB7,UD10,TT3,FC7,DN2,DW12,AR3,DJ5,DJ9,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S50,S5875,C250,C340,C400,C590,C3100,D5875,E135,E145,E230,E320,E400,E3300,A30,A120,A270,A305,A545,A1500,A2950,W275,W5625,F5250">
-				</p>
-                <p>EL3,EL4,EL7,EL12,AN5,AN12,GB4,GB7,UD10,TT3,FC7,DN2,DW12,AR3,DJ5,DJ9,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,</p>
-                <p>S50,S5875,</p>
-                <p>C250,C340,C400,C590,C3100,</p>
-                <p>D5875,</p>
-                <p>E135,E145,E230,E320,E400,E3300,</p>
-                <p>A30,A120,A270,A305,A545,A1500,A2950,</p>
-                <p>W275,W5625,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: Buff spells cast and F6000.</p>
-				<p><b>Notes</b>: Run the build several times in a row to buff Max Assistants to a higher degree.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Max Assistants (High Gems)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5, at least 2d 14h this game (F6000 included)</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Undead</p>
-				<p><b>Bloodline (Needs Testing)(2 days+ D5625)</b>: Archon</p>
-                <p><b>A2950</b>: Makers</p>
-				<p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL4,EL7,EL12,AN5,GB4,UD10,DM9,TT3,DD11,DN2,DW12,DG7,AR2,DJ5,DJ9,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S50,S200,S400,S5875,C175,C250,C340,C400,C5875,D5875,D200,D275,D290,E135,E3300,E5375,A2950,A5875,W180,W205,W275,W400,W525,W1400,W5625,F5250">
-				</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL4,EL7,EL12,AN5,GB4,UD10,DM9,TT3,DD11,DN2,DW12,DG7,AR3,DJ5,DJ9,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S50,S200,S400,S5875,C175,C250,C340,C400,C5875,D5875,D200,D275,D290,E135,E3300,E5375,A2950,A5875,W180,W205,W275,W400,W525,W1400,W5625,F5250">
-				    <b>5e7 (50 M)+ clicks</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL4,EL7,EL12,AN5,GB4,UD10,DM9,TT3,DD11,DN2,DW12,DG7,AR2,DJ5,DJ9,SP:Fairy Chanting,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DW,UNN:DG,S50,S200,S400,S5875,C175,C250,C340,C400,C5875,D5625,D200,D275,D290,E135,E3300,E5375,A2950,A5875,W180,W205,W275,W400,W525,W1400,W5625,F5250">
-					<b>Needs Testing: 2 day+ D5625</b>
-				</p>
-				<p>EL3,EL4,EL7,EL12,AN5,GB4,UD10,DM9,TT3,DD11,DN2,DW12,DG7,AR2,DJ5,DJ9,</p>
-				<p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,</p>
-				<p>S50,S200,S400,S5875,</p>
-				<p>C175,C250,C340,C400,C5875,</p>
-				<p>D5875,D200,D275,D290,</p>
-				<p>E135,E3300,E5375,</p>
-				<p>A2950,A5875,</p>
-				<p>W180,W205,W275,W400,W525,W1400,W5625,</p>
-				<p>F5250</p>
-                 <p><b>Notes</b>: Swap AR2 with AR3 if clicks are buffed (5e7 (50 M)+).</p>
-				<p><b>Notes</b>: <b>Needs Testing</b> Swap D5875 with D5625, Precognition with Infinite Spiral and use Archon Lineage if D5625 is buffed (2 day+).</p>
-            </div>
-        </div>
-		<br />
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182+ Clicks</a></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Aramil Nailo</p>
-				<p><b>Range</b>: 1e66 (1 Uvg) Gems+</p>
-                <p><b>Faction</b>: Elf</p>
-                <p><b>Bloodline</b>: Faceless</p>
-                <p><b>Artifact Set</b>: Faceless</p>
-                <p><b>Stoneheart Set</b>: Elf</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="S30,S105,S135,S150,S175,S200,S215,S330,S400,S500,S545,S3200,C1,C105,C150,C250,C340,C400,C500,C520,C590,C3100,D50,D290,D5625,E25,E30,E320,E5625,A55,A105,A120,A250,A270,A305,A400,A495,A545,A3400,W10,W120,W135,W150,W180,W200,W250,W290,W320,W330,W400,W560,W1275,W1375,F5750">
-				</p>
-                <p>S30,S105,S135,S150,S175,S200,S215,S330,S400,S500,S545,S3200,</p>
-                <p>C1,C105,C150,C250,C340,C400,C500,C520,C590,C3100,</p>
-                <p>D50,D290,D5625,</p>
-                <p>E25,E30,E320,E5625,</p>
-                <p>A55,A105,A120,A250,A270,A305,A400,A495,A545,A3400,</p>
-                <p>W10,W120,W135,W150,W180,W200,W250,W290,W320,W330,W400,W560,W1275,W1375,</p>
-                <p>F5750</p>
-				<p><b>Notes</b>: Buffing D5625 is recommended.</p>
-				<p><b>Notes</b>: Estimated time to God's Fingers is 3 days 4 hours (with 5 hours D5625).</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R202+ Clicks</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-				<p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 4, less than 3 hours D5625 (Use previous build with D5625 buff)</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Djinn</p>
-				<p><b>A2950</b>: Elf</p>
-				<p><b>D5875</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:DG,S200,S5625,C590,C5375,D5875,E135,E145,E320,E5375,A120,A270,A305,A545,A1500,A2950,W180,W275,W400,W1275,W1375,W1400,F5500">
-				</p>
-                <p>EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,</p>
-                <p>SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:DG,</p>
-                <p>S200,S5625,</p>
-                <p>C590,C5375,</p>
-                <p>D5875,</p>
-                <p>E135,E145,E320,E5375,</p>
-                <p>A120,A270,A305,A545,A1500,A2950,</p>
-                <p>W180,W275,W400,W1275,W1375,W1400,</p>
-                <p>F5500</p>
-				<p><b>Notes</b>: Estimated time to God's Fingers is 3 days 10 hours.</p>
-            </div>
-        </div>
-		<br />
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R202+ Max Mana Regen</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Rellikrellik</p>
-				<p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 4</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-				<p><b>A2950</b>: Dragon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN3,AN5,AN6,AN8,AN12,GB4,GB7,UD10,DD11,DN2,DW12,AR2,DJ5,DJ7,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AN,UNN:AR,S500,S5625,S150,S200,S215,S305,S330,S400,C5625,C175,C250,C340,C400,C500,D25,D55,D200,D275,D290,D320,D330,D1275,D3350,E135,E145,E230,E290,E320,E400,E495,E1325,E3300,A30,A120,A250,A270,A305,A545,A1500,A2950,W5625,W1275,W400,W205,W275,F5250">
-				</p>
-                <p>EL3,EL7,AN3,AN5,AN6,AN8,AN12,GB4,GB7,UD10,DD11,DN2,DW12,AR2,DJ5,DJ7,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AN,UNN:AR,</p>
-                <p>S500,S5625,S150,S200,S215,S305,S330,S400,</p>
-                <p>C5625,C175,C250,C340,C400,C500,</p>
-                <p>D25,D55,D200,D275,D290,D320,D330,D1275,D3350,</p>
-                <p>E135,E145,E230,E290,E320,E400,E495,E1325,E3300,</p>
-                <p>A30,A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W5625,W1275,W400,W205,W275,</p>
-                <p>F5250</p>
-				<p><b>Notes</b>: Do excavation resets to buff C5625.</p>
-				<p><b>Notes</b>: Target Catalyst at Gem Grinder for maximum benefits.</p>
-            </div>
-        </div>
-		<br />
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182-R198 Excavator</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e75 (1 Qavg) Gems+</p>
-                <p><b>Faction</b>: Evil/Chaos Mercenary</p>
-                <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Faceless</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL11,AN5,AN8,AN12,GB4,GB7,UD10,DM9,TT3,DD6,DN2,DW12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DN,D5875,S200,S400,S5875,S30,S105,S135,S150,S180,S215,S270,S330,C5125,C175,C340,C400,C25,C80,C105,C120,C135,C150,C250,C305,C590,D290,D330,D200,D25,D55,D135,D150,D245,D275,D320,E5125,E135,E230,E290,E320,E25,E30,E80,E145,E150,E200,E275,E350,E480,A270,A305,A2950,A25,A30,A55,A105,A120,A135,A150,A175,A200,A250,A300,A330,A375,A480,W5125,W1275,W275,W400,W25,W525,W205,F5500">
-				</p>
-                <p>EL3,EL11,AN5,AN8,AN12,GB4,GB7,UD10,DM9,TT3,DD6,DN2,DW12,DJ3,DJ5,DJ7,</p>
-				<p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:DN,</p>
-                <p>S200,S400,S5875,S30,S105,S135,S150,S180,S215,S270,S330,</p>
-                <p>C5125,C175,C340,C400,C25,C80,C105,C120,C135,C150,C250,C305,C590,</p>
-                <p>D5875,D290,D330,D200,D25,D55,D135,D150,D245,D275,D320,</p>
-                <p>E5125,E135,E230,E290,E320,E25,E30,E80,E145,E150,E200,E275,E350,E480,</p>
-                <p>A270,A305,A2950,A25,A30,A55,A105,A120,A135,A150,A175,A200,A250,A300,A330,A375,A480,</p>
-                <p>W5125,W1275,W275,W400,W25,W525,W205,</p>
-                <p>F5500</p>
-				<p><b>Notes</b>: Buffing W275, S400 is important.</p>
-				<p><b>Notes</b>: Maelstrom should buff HoL with assistants.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R198-R206 Excavator</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e90 (1 Novg) Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 3</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Elf</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p><b>MCC4 Union (R202+)</b>: Makers</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D200,D275,D290,D5125,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:MK,UNN:DG,S30,S50,S330,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D200,D275,D290,D5125,E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,A10,A105,A150,A175,A250,A305,A545,A1500,A2950,W25,W275,W525,W5125,F5750">
-					<b>MCC4 completed (R202+)</b>
-				</p>
-                <p>EL3,EL7,EL11,AN5,GB4,UD10,DM9,TT3,TT6,FC7,DN2,DW12,AR3,AR10,DJ5,DJ7,</p>
-                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DG,</p>
-                <p>S30,S50,S330,S400,S5125,</p>
-                <p>C25,C80,C175,C250,C340,C5125,</p>
-                <p>D25,D55,D200,D275,D290,D5125,</p>
-                <p>E1,E25,E30,E80,E135,E145,E150,E230,E290,E320,E350,E400,E495,E3300,</p>
-                <p>A10,A105,A150,A175,A250,A305,A545,A1500,A2950,</p>
-                <p>W25,W275,W525,W5125,</p>
-                <p>F5750</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Excavator</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Makers</p>
-				<p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,EL11,AN5,AN8,GB4,UD10,DM9,TT3,TT6,DN2,DW12,AR3,AR10,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,S5875,S50,S200,S400,S1500,C5125,C340,C250,C400,C590,D5875,D200,D275,D290,D330,D1375,E290,E400,E3300,E5375,A2950,A5875,A30,A270,W5125,W205,W275,W400,W525,W1275,W180,W1400,F5250">
-				</p>
-                <p>EL3,EL7,EL11,AN5,AN8,GB4,UD10,DM9,TT3,TT6,DN2,DW12,AR3,AR10,DJ5,DJ7,</p>
-                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Flesh Workshop,UNN:MK,UNN:DG,</p>
-                <p>S5875,S50,S200,S400,S1500,</p>
-                <p>C5125,C340,C250,C400,C590,</p>
-                <p>D5875,D200,D275,D290,D330,D1375,</p>
-                <p>E290,E400,E3300,E5375,</p>
-                <p>A2950,A5875,A30,A270,</p>
-                <p>W5125,W205,W275,W400,W525,W1275,W180,W1400,</p>
-                <p>F5250</p>
-				<p><b>Notes</b>: Benefits from buffing F6000, assistants and spell casts.</p>
-				<p><b>Notes</b>: Capable of excavating Ruby #55 (at Excavation 77000)</p>
-            </div>
-        </div>
-		<br />
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182-R190 F6000</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Kiluh</p>
-                <p><b>Range</b>: ?</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Faceless</p>
-                <p><b>A2950</b>: Makers</p>
-                <p><b>D5875</b>: Archon</p>
-                <p><b>Artifact Set</b>: Dragon</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD4,DD10,FC2,FC11,DN2,AR2,AR5,AR10,DJ9,SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,S200,S400,S5875,S30,S150,S215,S270,S330,S2875,C175,C250,C340,C400,C590,C5875,C1300,C1500,D5875,D200,D290,D330,D25,D55,D275,D320,D1275,D1375,E135,E320,E1425,E5625,E330,E350,E400,E480,E1225,A120,A270,A2950,A5375,A305,W275,W400,W1275,W1375,W5125,W120,W150,W180,W1400,F6000">
-				</p>
-                <p>EL7,AN5,AN8,AN12,GB4,GB7,TT3,DD4,DD10,FC2,FC11,DN2,AR2,AR5,AR10,DJ9,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,</p>
-                <p>S200,S400,S5875,S30,S150,S215,S270,S330,S2875,</p>
-                <p>C175,C250,C340,C400,C590,C5875,C1300,C1500,</p>
-                <p>D5875,D200,D290,D330,D25,D55,D275,D320,D1275,D1375,</p>
-                <p>E135,E320,E1425,E5625,E330,E350,E400,E480,E1225,</p>
-                <p>A120,A270,A2950,A5375,A305,</p>
-                <p>W275,W400,W1275,W1375,W5125,W120,W150,W180,W1400,</p>
+                <p>S1,S30,S180,S215,S400,S5125,</p>
+                <p>C10,C105,C340,C400,C5125,</p>
+                <p>D55,D135,D150,D205,D225,D245,D250,D290,D320,D435,D480,D525,D1275,D1375,</p>
+                <p>E30,E50,E80,E135,E145,E150,E200,E250,E290,E320,E330,E400,E410,E460,E480,E1325,</p>
+                <p>A30,A55,A105,A120,A135,A150,A200,A250,A305,A330,A400,A480,A3400,</p>
+                <p>W120,W135,W150,W180,W200,W250,W400,W1375,W3150,</p>
                 <p>F6000</p>
-				<p><b>Notes</b>: <b>Recast all spells before abdicating</b>.</p>
+                <p><b>Notes</b>: Used for getting fairy time to buff fairy set and lightning strike casts for buffing titan challenge 4. If you don’t use fairy set in your current reincarnation, use any evil alignment instead. Normal recommendation is to run for one hour, but can be run for up to a day, starting at a couple minutes and gradually upping as you get through Rs. Particularly useful to run at the start of a reincarnation if using long spells short burn at r180-190 or final verdict/benevolent warchant at r198+/r206+. Nothing in the build is important; this is simply for convenience of having a copyable set of researches that allows you to get something set up while ensuring you don’t accidentally pick up spell duration upgrades that would negatively impact the lightning strike casts.</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R190+ F6000</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Drow Perk 1 Buff</a></b></p>
             <div class="autohide">
                 <p><b>Author</b>: Ensteffahn</p>
                 <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 1</p>
+                <p><b>Faction</b>: Fairy</p>
+                <p><b>Bloodline</b>: Drow</p>
+                <p><b>Artifact Set</b>: Fairy</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="S1,S30,S105,S180,S200,S5375,C10,C80,C5875,D55,D290,D5625,E30,E50,E80,E135,E145,E150,E200,E250,E290,E320,E330,E400,E410,E460,E480,E1325,A30,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A480,A495,A545,A1325,W120,W135,W150,W180,W200,W250,W290,W320,W330,W400,W560,W1275,W1375,F5500">
+				</p>
+                <p>S1,S30,S105,S180,S200,S5375,</p>
+                <p>C10,C80,C5875,</p>
+                <p>D55,D290,D5625,</p>
+                <p>E30,E50,E80,E135,E145,E150,E200,E250,E290,E320,E330,E400,E410,E460,E480,E1325,</p>
+                <p>A30,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A480,A495,A545,A1325,</p>
+                <p>W120,W135,W150,W180,W200,W250,W290,W320,W330,W400,W560,W1275,W1375,</p>
+                <p>F5500</p>
+                <p><b>Notes</b>: Only needs to be run once at some point before A4. Increases combo strike count primarily through DJC1 and Drow challenge reward. <b>DO NOT</b> recast fairy chanting; instead, update its duration by exporting your save and reimporting it. This prevents the DJC1 effect from being reset. Benefits from buffing s5375 and d5625; one strategy is buffing s5375 and d5625 (fairy faction last) at r206 while gaining time for neutral,evil,order, and balance, and running this build for the last day to complete the MCC5 requirement and buff DWP1 simultaneously. Recommended value to aim for is ~300%(?)</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R180+ Mana Produced</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Rade, assisted by Regulus</p>
+                <p><b>Requirement</b>: R180</p>
+                <p><b>Range</b>: ?</p>
                 <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Titan</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,AN8,AN12,GB3,UD7,DM2,TT8,TT10,DD10,FC3,DN9,DW6,AR5,AR10,DJ3,SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace,UNN:AR,S30,S105,S135,S150,S180,S200,S215,S250,S270,S300,S330,S400,S435,S460,S545,S590,S1275,C25,C5875,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D350,D480,D560,D590,D1375,E25,E30,E135,E145,E150,E230,E250,E275,E290,E320,E350,E480,E3300,A30,A55,A105,A120,A135,A150,A175,A250,A270,A305,A375,A495,A545,A2950,W25,W120,W135,W150,W175,W180,W250,W260,W275,W290,W330,W400,W590,W1275,W1375,F5500">
+				</p>
+                <p>AN4,AN5,AN8,AN12,GB3,UD7,DM2,TT8,TT10,DD10,FC3,DN9,DW6,AR5,AR10,DJ3,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace,UNN:AR,</p>
+                <p>S30,S105,S135,S150,S180,S200,S215,S250,S270,S300,S330,S400,S435,S460,S545,S590,S1275,</p>
+                <p>C25,C5875,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D350,D480,D560,D590,D1375,</p>
+                <p>E25,E30,E135,E145,E150,E230,E250,E275,E290,E320,E350,E480,E3300,</p>
+                <p>A30,A55,A105,A120,A135,A150,A175,A250,A270,A305,A375,A495,A545,A2950,</p>
+                <p>W25,W120,W135,W150,W175,W180,W250,W260,W275,W290,W330,W400,W590,W1275,W1375,</p>
+                <p>F5500</p>
+                <p><b>Notes</b>: Used for increasing primal balance values to assist with crossing higher gem thresholds in R180-R190 more quickly. Reset spells periodically, especially fairy chanting for max mana. Capable of 1e18 max mana/regen at e80 gems, requires buffing max ziggurat count. Also allows TTC4 buffing.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R190+ Mana Produced</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Follower</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Range</b>: ?</p>
+                <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>A2950</b>: Titan</p>
+                <p><b>MCC4</b>: Titan</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,AN8,AN12,GB6,UD7,TT8,TT10,DD10,FC2,FC3,FC11,DN2,DN9,DW6,DJ3,SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace,UNN:AR,UNN:TT,S200,S400,S5875,C400,C5875,D200,D290,D330,D5625,E135,E230,E320,E1325,E3300,A2950,A270,A5375,W275,W400,W1275,W1375,F5750">
+				</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="S375,S545,S590,S1275,C175,C375,C460,C590,C1325,C340,D275,D480,D590,D1375,E275,E290,E480,E590,E1425,E145,A30,A120,A495,W175,W290,W560,W590">
+                    <b>Additional researches to buff DJ3</b>
+				</p>
+                <p>AN4,AN5,AN8,AN12,GB6,UD7,TT8,TT10,DD10,FC2,FC3,FC11,DN2,DN9,DW6,DJ3,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace,UNN:AR,UNN:TT,</p>
+                <p>S200,S400,S5875,</p>
+                <p>C400,C5875,</p>
+                <p>D200,D290,D330,D5625,</p>
+                <p>E135,E230,E320,E1325,E3300,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W275,W400,W1275,W1375,</p>
+                <p>F5750</p>
+                <p><b>Additional researches to buff DJ3</b>:</p>
+                <p>S375,S545,S590,S1275,</p>
+                <p>C175,C375,C460,C590,C1325,C340,</p>
+                <p>D275,D480,D590,D1375,</p>
+                <p>E275,E290,E480,E590,E1425,E145,</p>
+                <p>A30,A120,A495,</p>
+                <p>W175,W290,W560,W590</p>
+                <p><b>Notes</b>: At high F6000 (~7 hrs), swap Lineage and A2950, then put Brainwave in for Fairy Chanting. Do not cast Lightning Strike before buying S300 to buff TTC4</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Mana Produced + DM2</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
                 <p><b>Bloodline</b>: Faceless</p>
                 <p><b>A2950</b>: Fairy</p>
-                <p><b>Artifact Set</b>: Dragon</p>
-				<p><b>MCC4 Union (R202+)</b>: Titan</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR1,EL4,EL7,AN5,AN8,AN12,GB7,DD4,DD10,FC2,FC11,DN2,AR2,AR5,DJ9,MK10,SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,S5875,S200,S400,S5125,C5875,C175,C250,C340,C400,C5375,D200,D275,D290,D330,D1375,D3350,E5625,E135,E230,E320,E1425,E5125,A5375,A120,A270,A305,A2950,A3400,W180,W275,W400,W1275,W1375,W5125,F6000,F5250">
+                    <input type="text" value="AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,S200,S400,S5875,C340,C400,C5875,D200,D275,D290,D330,D5625,E135,E145,E5625,A5375,A270,A2950,A30,A120,W275,W400,W1275,W5625,F5250">
 				</p>
-				<p>
+                <p>AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,</p>
+                <p>S200,S400,S5875,</p>
+                <p>C340,C400,C5875,</p>
+                <p>D200,D275,D290,D330,D5625,</p>
+                <p>E135,E145,E5625,</p>
+                <p>A5375,A270,A2950,A30,A120,</p>
+                <p>W275,W400,W1275,W5625,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Needs some F6000 to be able to afford A researches</p>
+                <p><b>Notes</b>: After buying these researches, get stuff for prod/dj3</p>
+                <p><b>Notes</b>: Reached 3e24(7e24 w/ gem grinder) MM in 30 min, done at 23h F6000</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Mana Produced + DM2</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR1,EL4,EL7,AN5,AN8,AN12,GB7,DD4,DD10,FC2,FC11,DN2,AR2,AR5,DJ9,MK10,SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:TT,UNN:AR,S5875,S200,S400,S5125,C5875,C175,C250,C340,C400,C5375,D200,D275,D290,D330,D1375,D3350,E5625,E135,E230,E320,E1425,E5125,A5375,A120,A270,A305,A2950,A3400,W180,W275,W400,W1275,W1375,W5125,F6000,F5250">
-					<b>Mercenary Challenge 4</b>
+                    <input type="text" value="AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,S200,S400,S5875,C340,C400,C5875,D200,D275,D290,D330,D5625,E135,E145,E5625,A5375,A270,A2950,A30,A120,W275,W400,W1275,W5625,F5250">
 				</p>
-                <p>FR1,EL4,EL7,AN5,AN8,AN12,GB7,DD4,DD10,FC2,FC11,DN2,AR2,AR5,DJ9,MK10,</p>
+                <p>AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,</p>
+                <p>S200,S400,S5875,</p>
+                <p>C340,C400,C5875,</p>
+                <p>D200,D275,D290,D330,D5625,</p>
+                <p>E135,E145,E5625,</p>
+                <p>A5375,A270,A2950,A30,A120,</p>
+                <p>W275,W400,W1275,W5625,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Needs some F6000 to be able to afford A researches</p>
+                <p><b>Notes</b>: After buying these researches, get stuff for prod/dj3</p>
+                <p><b>Notes</b>: Reached 3e24(7e24 w/ gem grinder) MM in 30 min, done at 23h F6000</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">High Mana Produced (R219?)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Drow</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,AN8,GB6,UD7,DM2,DD10,DD11,FC3,DN2,DN9,AN12,AR12,DJ3,DJ5,DJ7,SP:Brainwave,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:TT,S200,S400,S5875,S5125,C175,C340,C400,C5875,C5125,D200,D275,D290,D330,D5625,E135,E230,E290,E320,E3300,E5625,A120,A270,A2950,A5375,W275,W5625,W1275,W5125,F5250,F5500">
+				</p>
+                <p>AN4,AN5,AN8,GB6,UD7,DM2,DD10,DD11,FC3,DN2,DN9,AN12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Brainwave,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:TT,</p>
+                <p>S200,S400,S5875,S5125,</p>
+                <p>C175,C340,C400,C5875,C5125,</p>
+                <p>D200,D275,D290,D330,D5625,</p>
+                <p>E135,E230,E290,E320,E3300,E5625,</p>
+                <p>A120,A270,A2950,A5375,</p>
+                <p>W275,W5625,W1275,W5125,</p>
+                <p>F5250,F5500</p>
+                <p><b>Notes</b>: Use additional points for dj3 buff</p>
+                <p><b>Notes</b>: Needs f6000 buffed, needs around 2d/1d R time/evil time, to afford all researches. Needs DWP1 buffed (tested at 300%), Swap AN12->DN12, if over 1,5d(?) as an alignment</p>
+                <p><b>Notes</b>: Should be able to reach up to 1e26 Max mana</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R180+ Excavation Resets</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Nov'Art</p>
+                <p><b>Range</b>: ?</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Makers</p>
+                <p><b>A2950</b>: Archon</p>
+                <p><b>Artifact Set</b>: Demon</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,AN12,GB3,GB6,UD7,UD10,FC3,DD11,DN2,DN8,DW7,DW12,AR2,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,S5125,S200,S50,S135,S150,S400,S330,S215,S250,S180,S30,S105,C5125,C340,C400,C175,C250,C590,C25,C105,C150,D1375,D2775,D275,D290,D200,D330,D590,D320,D55,D135,D150,D25,D245,D250,E290,E3300,E1225,E230,E135,E320,E1,E25,E30,E145,E400,E460,E495,A2950,A1500,A30,A120,A410,A545,A10,A105,A150,A250,A270,A305,A375,A55,W5125,W275,W400,W205,W25,W135,W150,W180,W250,W175,W120,F5750">
+				</p>
+                <p>AN4,AN5,AN12,GB3,GB6,UD7,UD10,FC3,DD11,DN2,DN8,DW7,DW12,AR2,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:DW,</p>
+                <p>S5125,S200,S50,S135,S150,S400,S330,S215,S250,S180,S30,S105,</p>
+                <p>C5125,C340,C400,C175,C250,C590,C25,C105,C150,</p>
+                <p>D1375,D2775,D275,D290,D200,D330,D590,D320,D55,D135,D150,D25,D245,D250,</p>
+                <p>E290,E3300,E1225,E230,E135,E320,E1,E25,E30,E145,E400,E460,E495,</p>
+                <p>A2950,A1500,A30,A120,A410,A545,A10,A105,A150,A250,A270,A305,A375,A55,</p>
+                <p>W5125,W275,W400,W205,W25,W135,W150,W180,W250,W175,W120,</p>
+                <p>F5750</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R198+ Excavation Resets</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Requirement</b>: MCC3</p>
+                <p><b>Range</b>: ?</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Makers</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL5,EL12,GB3,GB4,GB6,UD10,FC3,DN2,DN8,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:MK,UNN:DG,S30,S180,S200,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,E25,E30,E135,E145,E230,E290,E5125,A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,W25,W175,W275,W400,W5125,F5750">
+				</p>
+                <p>EL5,EL12,GB3,GB4,GB6,UD10,FC3,DN2,DN8,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:MK,UNN:DG,</p>
+                <p>S30,S180,S200,S400,S5125,</p>
+                <p>C25,C80,C175,C250,C340,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,</p>
+                <p>E25,E30,E135,E145,E230,E290,E5125,</p>
+                <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
+                <p>W25,W175,W275,W400,W5125,</p>
+                <p>F5750</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R198+ Max Excavations</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Requirement</b>: MCC3</p>
+                <p><b>Range</b>: ?</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL5,EL12,GB3,GB4,GB6,UD10,FC3,DN2,DN8,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Brothel,UNN:MK,UNN:DG,S30,S180,S200,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,E25,E30,E135,E145,E230,E290,E5125,A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,W25,W175,W275,W400,W5125,F5750">
+				</p>
+                <p>EL5,EL12,GB3,GB4,GB6,UD10,FC3,DN2,DN8,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,</p>
+                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Brothel,UNN:MK,UNN:DG,</p>
+                <p>S30,S180,S200,S400,S5125,</p>
+                <p>C25,C80,C175,C250,C340,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,</p>
+                <p>E25,E30,E135,E145,E230,E290,E5125,</p>
+                <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
+                <p>W25,W175,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <br/>
+                <p><b>Alternative for when you inf out on excavs (high max excavs at the end of r219)</b></p>
+                <br/>
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL5,EL12,GB3,GB4,GB6,UD10,FC3,DN2,DN8,DN9,DW7,DW12,AR12,DJ3,DJ5,DJ7,SP:Grand Balance,SP:Infinite Spiral,UB:Brothel,UNN:MK,UNN:DG,S30,S180,S200,S400,S5125,C25,C80,C175,C250,C340,C5125,D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1375,E25,E30,E135,E145,E230,E290,E5125,A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,W25,W175,W275,W400,W5125,F5750">
+				</p>
+                <p>EL12,AN4,AN5,GB3,UD10,GB4,FC3,DN2,DN8,DN9,DW7,DW10,DW12,DJ3,DJ7,MK6,</p>
+                <p>SP:Grand Balance,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,UNN:DW,</p>
+                <p>S30,S180,S200,S400,S5125,</p>
+                <p>C25,C105,C340,C400,C5125,</p>
+                <p>D25,D55,D135,D150,D200,D245,D250,D275,D290,D320,D330,D400,D480,D560,D590,D1275,</p>
+                <p>E135,E290,E400,E5125,</p>
+                <p>A30,A55,A105,A120,A270,A305,A545,A1500,A2950,</p>
+                <p>W180,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: buff assistants like crazy, f6000</p>
+                <p><b>Notes</b>: At coin cap: DJ7->DJ9, DJ3->DM2, GB4->GB6, S researches->S5875?, F5750->F5250 if you have offline time. If you can still reach cap: Grand balance-> moon blessing</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">F6000 Buff (R182-R190)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>A2950</b>: Archon</p>
+                <p><b>Artifact Set</b>: Dragon</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="DN2,DM2,FC3,AR2,AN4,AN5,AR5,DW6,AN8,UD7,DN9,DW7,DD10,FC11,AN12,AR10,SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,S180,S200,S400,S5125,C175,C340,C5125,D200,D275,D290,D330,E320,E135,E1325,A2950,A270,A5375,W275,W1275,W1375,W400,W180,F6000,F5500">
+				</p>
+                <p>DN2,DM2,FC3,AR2,AN4,AN5,AR5,DW6,AN8,UD7,DN9,DW7,DD10,FC11,AN12,AR10,</p>
                 <p>SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,</p>
-                <p>S5875,S200,S400,S5125,</p>
-                <p>C5875,C175,C250,C340,C400,C5375,</p>
-                <p>D200,D275,D290,D330,D1375,D3350,</p>
-                <p>E5625,E135,E230,E320,E1425,E5125,</p>
-                <p>A5375,A120,A270,A305,A2950,A3400,</p>
-                <p>W180,W275,W400,W1275,W1375,W5125,</p>
-                <p>F6000,F5250</p>
-
-				<p><b>Notes</b>: <b>Recast all spells before abdicating</b>.</p>
+                <p>S180,S200,S400,S5125,</p>
+                <p>C175,C340,C5125,</p>
+                <p>D200,D275,D290,D330,</p>
+                <p>E320,E135,E1325,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W275,W1275,W1375,W400,W180,</p>
+                <p>F6000,F5500</p>
+                <p><b>Notes</b>: After buying A5375, buy A120 and A545</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">F6000 Buff (R190+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Druid</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>MCC4</b>: Titan</p>
+                <p><b>Artifact Set</b>: Druid</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="DN2,DM2,FC3,AR2,AN4,AN5,FR4,AR5,DW7,AN8,UD7,DN9,DD10,MK10,AN11,FC11,SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,UNN:TT,S200,S5875,S5125,C340,C400,C5625,C5875,C175,D200,D330,D290,D275,D320,D1375,E135,E1425,E5625,E30,A2950,A270,A5375,W1275,W275,W5125,W400,W1375,F6000,F5500">
+				</p>
+                <p>DN2,DM2,FC3,AR2,AN4,AN5,FR4,AR5,DW7,AN8,UD7,DN9,DD10,MK10,AN11,FC11,</p>
+                <p>SP:Dragon's Breath,SP:Precognition,UB:Ziggurat,UNN:AR,UNN:TT,</p>
+                <p>S200,S5875,S5125,</p>
+                <p>C340,C400,C5625,C5875,C175,</p>
+                <p>D200,D330,D290,D275,D320,D1375,</p>
+                <p>E135,E1425,E5625,E30,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W1275,W275,W5125,W400,W1375,</p>
+                <p>F6000,F5500</p>
+                <p><b>Notes</b>: For multiple day f6000, buffing dm2 is recommended. Secondary researches to spend extra points on: S400,S2875,S180,C5125,C250,A120,A305,A3400,W3050</p>
+                <p><b>Notes</b>: Buy E3300 only when you're ready to abdicate. E3300 tanks the production of the build but massively boosts F6000. Buy any buildings that E3300 provides with the building cost reduction, refresh all spells and then abdicate.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Lineage Leveler (R180-R193)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44, Regulus</p>
+                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Fairy (first)</p>
+                <p><b>A2950</b>: Elf</p>
+                <p><b>Artifact Set</b>: Faceless</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL1,MK1,FC2,FC3,AN5,AR5,DD6,GB6,EL7,UD7,DW7,DJ9,EL11,UD10,DW12,AN12,SP:Dragon's Breath,SP:Infinite Spiral,UNN:DG,UB:Dragon Pasture,S400,S200,S5125,C5375,C400,C175,D275,D290,D200,D330,D3350,E5625,E320,A30,A120,A270,A305,A545,A2950,A1500,W275,W1275,W1375,W400,F5250">
+				</p>
+                <p>EL1,MK1,FC2,FC3,AN5,AR5,DD6,GB6,EL7,UD7,DW7,DJ9,EL11,UD10,DW12,AN12,</p>
+                <p>SP:Dragon's Breath,SP:Infinite Spiral,UNN:DG,UB:Dragon Pasture,</p>
+                <p>S400,S200,S5125,</p>
+                <p>C5375,C400,C175,</p>
+                <p>D275,D290,D200,D330,D3350,</p>
+                <p>E5625,E320,</p>
+                <p>A30,A120,A270,A305,A545,A2950,A1500,</p>
+                <p>W275,W1275,W1375,W400,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Elfline -> A2950:maker/druid(?). Dragonline/Makersline -> Replace Dragon Breath/Infinite Spiral with Lightning Strike (shouldn’t matter too much either). Use the artifact set of the lineage you are levelling. Buff Excavations and resets.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Druid Lineage 75 (R194+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Rade</p>
+                <p><b>Requirement</b>: MCC2</p>
+                <p><b>Faction</b>: Neutral/Chaos Mercenary</p>
+                <p><b>Bloodline</b>: Druid</p>
+                <p><b>A2950</b>: Elf</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL7,EL11,AN4,AN5,AN11,GB7,UD7,UD10,DM2,FC2,FC3,DW6,DW7,DW12,AR5,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DN,S5875,C5375,C400,C175,D290,D330,D200,E3300,E145,E135,E290,E320,E1325,A250,A120,A270,A305,A1500,A2950,W1275,W1375,W1400,W275,W400,F5750">
+				</p>
+                <p>EL7,EL11,AN4,AN5,AN11,GB7,UD7,UD10,DM2,FC2,FC3,DW6,DW7,DW12,AR5,MK1,</p>
+                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DN,</p>
+                <p>S5875,</p>
+                <p>C5375,C400,C175,</p>
+                <p>D290,D330,D200,</p>
+                <p>E3300,E145,E135,E290,E320,E1325,</p>
+                <p>A250,A120,A270,A305,A1500,A2950,</p>
+                <p>W1275,W1375,W1400,W275,W400,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: First level druidline to ~70?, then bring elfline up to par, then run druid for the highest level.</p>
+                <p><b>Notes</b>: Recast spells during faceless lineage for maximum duration to increase druid advanced heritage. Fill in with other researches for additional production for additional buildings.Can reach lineage 75 within 8-16 hours with buffs for excavations/resets, flesh workshops, max assistants, evil time, cta activity time, gems, and a properly levelled elf lineage</p>
+                <p><b>Notes</b>: It is probably more worthwhile to wait for access to the better lineage build at 198+ to push to 75 - 73/74 should be achievable in a much shorter timeframe without sacrificing much benefit. For an approximate idea of how much buffing is needed, 75 was reached in approximately 17h without properly managing spell resets with 1.2e27 max assistants, 7e23 spells cast, 44 excavation resets.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Secondary Lineage Leveler (R194+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Rade</p>
+                <p><b>Requirement</b>: MCC2</p>
+                <p><b>Faction</b>: Neutral/Chaos Mercenary</p>
+                <p><b>Bloodline</b>: Any (best with Titan)</p>
+                <p><b>A2950</b>: Elf (or Titan if using Elf lineage)</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL7,EL11,AN4,AN5,AN11,UD7,UD10,DM2,FC2,FC3,DD6,DW7,DW12,AR5,DJ9,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DN,S30,S180,S200,S400,S500,C175,C400,C5375,D200,D290,D330,E135,E145,E230,E290,E320,E1325,E3300,A120,A270,A305,A1500,A2950,W135,W275,W400,W1275,W1375,W1400,F5750">
+				</p>
+                <p>EL7,EL11,AN4,AN5,AN11,UD7,UD10,DM2,FC2,FC3,DD6,DW7,DW12,AR5,DJ9,MK1,</p>
+                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DN,</p>
+                <p>S30,S180,S200,S400,S500,</p>
+                <p>C175,C400,C5375,</p>
+                <p>D200,D290,D330,</p>
+                <p>E135,E145,E230,E290,E320,E1325,E3300,</p>
+                <p>A120,A270,A305,A1500,A2950,</p>
+                <p>W135,W275,W400,W1275,W1375,W1400,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: Notes: If using dragon/makers lineage, swap in lightning strike as the remaining spell. Reset all your spells and reactivate them when faceless lineage is active from chaos madness, then most progress will be made when hitting either archon or titan lineages with it. If you're doing titan, get lightning strike to hit hall of legends when you recast. If numbers were buffed enough to reach Druid 75 in a night with the above build, then this should be able to get the rest of the lineages to 75 in no more than a few minutes each, most without needing to hit the right chaos madness targets.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Lineage Leveler (R198+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Any</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Matching your lineage, mercset for elite lineages</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL7,AN4,AN5,AN11,GB3,UD7,TT10,DD6,FC2,FC3,DN9,DW7,UD10,DW12,MK1,MK6,SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,UNN:TT,S200,S5625,C175,C400,C5375,D275,D5625,E135,E320,E5375,A120,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,F5500">
+				</p>
+                <p>EL7,AN4,AN5,AN11,GB3,UD7,TT10,DD6,FC2,FC3,DN9,DW7,UD10,DW12,MK1,MK6,</p>
+                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,UNN:TT,</p>
+                <p>S200,S5625,</p>
+                <p>C175,C400,C5375,</p>
+                <p>D275,D5625,</p>
+                <p>E135,E320,E5375,</p>
+                <p>A120,A270,A305,A545,A1500,A2950,</p>
+                <p>W275,W400,W1275,W1375,W180,</p>
+                <p>F5500</p>
+                <p><b>Notes</b>: Replace Titan Union with Drow Union if F6000 is less than ~80 hours. EL11 may provide more benefit than whichever is lower between UD10 and DW12. Switch DN9->AR8 if activity time over 8? hours? Optimized for R206+, but can still quickly produce 75+ lineages with MCC3 and no F6000. Level Druid lineage first. May require slight changes for other lineages. Can reach l95 in 1 hour, potentially l96 with the following buffs (try to line up with mcc5/god’s fingers to preserve buffs) Makerline with Elf A2950 may also work well as first.</p>
+                <p><b>Notes</b>: 4 day F6000, buff future linkin with double f6000 if desired. 19 h Fairy time. 5e26 spells. 2.5e39 assistants. 1e8 clicks this R. 0 h d5625 (can buff if desired during mcc5 waiting period). 100 Excavation Resets. Also buff max. Mountain palaces, flesh workshops, labyrinths. Try to buff activity time on spells during waiting period as well to speed up lineage leveling.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R190+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44, based on a build by Meirlu</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,S200,S400,S5875,S180,C5875,C175,C250,C340,C400,D200,D275,D290,D330,D1375,D5625,E3300,E135,E5125,E400,E495,E145,A2950,A270,A5375,W5625,W1275,W275,W400,W1375,W205,F5250">
+				</p>
+                <p>AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,</p>
+                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,</p>
+                <p>S200,S400,S5875,S180,</p>
+                <p>C5875,C175,C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,D5625,</p>
+                <p>E3300,E135,E5125,E400,E495,E145,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W5625,W1275,W275,W400,W1375,W205,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: After A5375: A30,A120,A305,A250,A1500</p>
+                <p><b>Notes</b>: Recommended F6000 16h? to buy A5375</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R198+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Gull</p>
+                <p><b>Requirement</b>: MCC3</p>
+                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Makers</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,S30,S5875,C5875,C105,D290,D5625,D55,D25,E135,E400,E5375,E30,E25,A30,A120,A270,A305,A545,A1500,A2950,A250,W180,W275,W400,W1275,W1375,W150,W175,W200,W250,F5250">
+				</p>
+                <p>EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,</p>
+                <p>S30,S5875,</p>
+                <p>C5875,C105,</p>
+                <p>D290,D5625,D55,D25,</p>
+                <p>E135,E400,E5375,E30,E25,</p>
+                <p>A30,A120,A270,A305,A545,A1500,A2950,A250,</p>
+                <p>W180,W275,W400,W1275,W1375,W150,W175,W200,W250,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Run multiple times to buff assistants more. Benefits from f6000  and mana produced. Recast Fairy Chanting to increase DN9.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Mana Regen (R202+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,S200,S3200,S5625,C250,C340,C400,C590,C5875,D200,D275,D290,D330,D5625,E135,E320,E3300,E5625,A5375,A270,A2950,A30,A120,A545,W1275,W5625,W275,W400,W1375,W205,F5250">
+				</p>
+                <p>FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,</p>
+                <p>S200,S3200,S5625,</p>
+                <p>C250,C340,C400,C590,C5875,</p>
+                <p>D200,D275,D290,D330,D5625,</p>
+                <p>E135,E320,E3300,E5625,</p>
+                <p>A5375,A270,A2950,A30,A120,A545,</p>
+                <p>W1275,W5625,W275,W400,W1375,W205,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Tested after MCC5, with ~6h this R/3h evil</p>
+                <p><b>Notes</b>: buff FR12 (titanline fairy is good enough, but can get a couple OoM more with a specific faceline fairy build (recommend for like 202-206)) and Mana produced, let grow until Catalyst hits Gem Grinder for maximum gains.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Clicks (R202+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Miracle Man0</p>
+                <p><b>Requirement</b>: 1e95 (100 Tg) Gems + (the more the better), MCC4</p>
+                <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Djinn</p>
+                <p><b>A2950</b>: Elf</p>
+                <p><b>Artifact Set</b>: Elf</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,S180,S200,S400,S5875,C175,C340,C400,C590,C5375,D200,D275,D290,D330,D1375,E145,E320,E5625,A120,A250,A270,A305,A545,A1500,A2950,W175,W180,W275,W400,W1275,W1375,W1400,F5500">
+				</p>
+                <p>EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,</p>
+                <p>SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,</p>
+                <p>S180,S200,S400,S5875,</p>
+                <p>C175,C340,C400,C590,C5375,</p>
+                <p>D200,D275,D290,D330,D1375,</p>
+                <p>E145,E320,E5625,</p>
+                <p>A120,A250,A270,A305,A545,A1500,A2950,</p>
+                <p>W175,W180,W275,W400,W1275,W1375,W1400,</p>
+                <p>F5500</p>
+                <p><b>Notes</b>: Neutral is used for C5375, order is used for makersline and all other bloodlines. Djinn lineage used for the perk to give autoclicks to LW. Elf A2950 for autoclicks.Once you buy all upgrades, speed of reaching God's Fingers depends on previous buffs which allow you to accumulate faction coins and boost the makerline power. Benefits from buffing max assistants (W275), excavations and resets (IS), max number of labyrinths (FC2), spells cast (S400). Running this at end of R gems is better as you boost DW12, will be able to afford more buildings (DW7), and likely will have boosted TTC4 earlier in the R as well. Since you have archonline, benefits from F6000 buffs, untested, may let you buy A3400, which is probably better than i.e. A545.</p>
+                <p><b>Notes</b>: Tested relatively unbuffed at 4e93 gems, took 100-110 hours to god's fingers, but I spent some time offline and lost LW autoclicks. With buffs I estimate God's Fingers in under 100 hours, perhaps as low as 3.5 days.</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Flesh Workshops and Brothels Buff (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Rade</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Goblin</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S30,S150,S180,S200,S215,S5125,C25,C105,C340,C400,C5125,D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,E30,E80,E135,E230,E400,E5125,A30,A105,A120,A150,A270,A305,A545,A1500,A2950,W180,W275,W400,W5125,F5750">
+				</p>
+                <p>AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,</p>
+                <p>S30,S150,S180,S200,S215,S5125,</p>
+                <p>C25,C105,C340,C400,C5125,</p>
+                <p>D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,</p>
+                <p>E30,E80,E135,E230,E400,E5125,</p>
+                <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
+                <p>W180,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: For buffing brothels switch Flesh Workshop->Brothel and AN4->FR4</p>
             </div>
         </div>
     </div>
     <br/>
-    <p><b>Artifact/Trophy Builds</b></p>
+    <p><b>Mercenary Challenges</b></p>
     <div class="category">
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Apeiron/True Harlequin</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">MCC1 Unlock</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Somarilnos</p>
-                <p><b>Range</b>: 1e30 (1 No) Gems+</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Titan</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR3,EL7,AN5,GB4,UD8,DM6,TT10,DD11,FC7,DN2,DW2,DG12,AR2,AR10,DJ7,MK6,SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace,C340,C400,E290,E400,E135,E145,E1325,A2950,A120,S400,D200,D275,D290,W275,W400">
-				</p>
-                <p>FR3,EL7,AN5,GB4,UD8,DM6,TT10,DD11,FC7,DN2,DW2,DG12,AR2,AR10,DJ7,MK6,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Mountain Palace</p>
-                <p>S400,</p>
-                <p>C340,C400,</p>
-                <p>D200,D275,D290,</p>
-                <p>E290,E400,E135,E145,E1325,</p>
-                <p>A2950,A120,</p>
-                <p>W275,W400</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Vault</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Marah</p>
-                <p><b>Range</b>: ?</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Titan</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL3,EL7,AN5,AN12,GB4,GB7,TT10,FC2,FC7,DN2,DW6,DW12,AR2,AR10,DJ7,MK6,SP:God's Hand,SP:Goblin's Greed,UB:Mountain Palace,UNN:EL,S200,S400,S435,S590,S1500,S2875,C25,C105,C340,C400,C590,C1500,C3000,D150,D275,D290,D2775,E25,E30,E135,E145,E275,E290,E320,E400,E460,E480,E590,E1325,E1425,A55,A105,A120,A250,A375,A590,A1500,A2950,W25,W120,W150,W180,W200,W275,W590,W1375,W3050">
-				</p>
-                <p>EL3,EL7,AN5,AN12,GB4,GB7,TT10,FC2,FC7,DN2,DW6,DW12,AR2,AR10,DJ7,MK6,</p>
-                <p>SP:God's Hand,SP:Goblin's Greed,UB:Mountain Palace,UNN:EL</p>
-                <p>S200,S400,S435,S590,S1500,S2875,</p>
-                <p>C25,C105,C340,C400,C590,C1500,C3000,</p>
-                <p>D150,D275,D290,D2775,</p>
-                <p>E25,E30,E135,E145,E275,E290,E320,E400,E460,E480,E590,E1325,E1425,</p>
-                <p>A55,A105,A120,A250,A375,A590,A1500,A2950,</p>
-                <p>W25,W120,W150,W180,W200,W275,W590,W1375,W3050</p>
-            </div>
-        </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mythos/Athanor</a></b><b><font color="Blue"> Good</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Glenniss2</p>
-                <p><b>Range</b>: 1e47 (100 Qad) Gems+</p>
-				<p><b>Requirements</b>: 2 Excavation Resets+</p>
-                <p><b>Faction</b>: Good/Order Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Dragon</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR7,EL3,EL4,EL7,EL11,AN5,GB4,TT3,FC7,DN2,DN10,DW12,AR2,AR10,DJ7,MK5,SP:Fairy Chanting,SP:Precognition,UB:High Bastion,UNN:DM,S150,S200,S215,S330,S400,S1275,C175,C250,C340,C400,C590,C3100,D200,D205,D275,D290,D330,D525,D1375,E30,E135,E145,E290,E320,E400,E460,E3300,A120,A305,A2950,A1500,A270,A545,A250,W175,W275,W400,W1375,W1275,W1400">
-				</p>
-                <p>FR7,EL3,EL4,EL7,EL11,AN5,GB4,TT3,FC7,DN2,DN10,DW12,AR2,AR10,DJ7,MK5,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:High Bastion,UNN:DM,</p>
-                <p>S150,S200,S215,S330,S400,S1275,</p>
-                <p>C175,C250,C340,C400,C590,C3100,</p>
-                <p>D200,D205,D275,D290,D330,D525,D1375,</p>
-                <p>E30,E135,E145,E290,E320,E400,E460,E3300,</p>
-                <p>A120,A305,A2950,A1500,A270,A545,A250</p>
-                <p>W175,W275,W400,W1375,W1275,W1400</p>
-				<p><b>Notes</b>: if you have Factory, get C3100.</p>
-				<p><b>Notes</b>: if you have Vault, get E3300.</p>
-				<p><b>Notes</b>: if you have Athanor, get A1500,A270,A545,A250.</p>
-				<p><b>Notes</b>: if you have Battlefield, get W1400.</p>
-				<p><b>Notes</b>: Additional researches are pre-included for ease of importing use.</p>
-            </div>
-        </div>
-    </div>
-	<br/>
-	<p><b>Challenge Builds</b></p>
-    <div class="category">
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mercenary Challenge 1</b></a><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e85 (10 Spvg) Gems+</p>
-				<p><b>Requirements</b>: 4 hours+ this Reincarnation</p>
+                <p><b>Author</b>: Kwazygloo (inspired by pizza_troll)</p>
                 <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
-                <p><b>A2950</b>: Dragon</p>
-				<p><b>D5875</b>: Archon</p>
+                <p><b>Bloodline</b>: Angel</p>
+                <p><b>A2950</b>: Archon</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="AN3,AN5,AN6,AN8,AN12,UD7,UD9,UD10,DN2,DW2,DW6,DW12,AR2,AR4,AR8,AR10,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:DW,S30,S105,S150,S200,S330,S400,S500,S5625,C25,C200,C250,C340,C400,C500,C5625,D5875,D200,D245,D290,D330,D400,E10,E30,E80,E135,E145,E290,E320,E330,E400,E480,E495,E1325,E3300,A55,A105,A120,A175,A250,A270,A305,A480,A545,A590,A1500,A2950,W205,W400,W1375,W5375,F6000">
+                    <input type="text" value="AN4,AN6,AN10,AN12,UD7,UD10,TT2,TT7,DN2,DN4,DN8,DW2,DW7,DW12,AR2,AR4,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,S30,S200,S400,S1275,S5625,C105,C135,C200,C250,C340,C400,C500,C5625,D200,D245,D290,D330,D400,D480,D5625,E30,E80,E135,E145,E250,E290,E320,E330,E400,E460,E495,E1325,E3300,A55,A120,A200,A250,A270,A305,A2950,A3400,W150,W205,W1275,W1375,W1400,W3150,F5750">
 				</p>
-                <p>AN3,AN5,AN6,AN8,AN12,UD7,UD9,UD10,DN2,DW2,DW6,DW12,AR2,AR4,AR8,AR10,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:DW,</p>
-                <p>S30,S105,S150,S200,S330,S400,S500,S5625,</p>
-                <p>C25,C200,C250,C340,C400,C500,C5625,</p>
-                <p>D5875,D200,D245,D290,D330,D400,</p>
-                <p>E10,E30,E80,E135,E145,E290,E320,E330,E400,E480,E495,E1325,E3300,</p>
-                <p>A55,A105,A120,A175,A250,A270,A305,A480,A545,A590,A1500,A2950,</p>
-                <p>W205,W400,W1375,W5375,</p>
-                <p>F6000</p>
-                <p><b>Notes</b>: Do a F6000 buff before the build.</p>
-				<p><b>Notes</b>: Remember to not buy any non-Order faction upgrades (Ex: Fairy heritage).</p>
-				<p><b>Notes</b>: Doing some excavation resets during the run is recommended.</p>
-				<p><b>Notes</b>: Estimated time to completion is 15 minutes or less.</p>
+                <p>AN4,AN6,AN10,AN12,UD7,UD10,TT2,TT7,DN2,DN4,DN8,DW2,DW7,DW12,AR2,AR4,</p>
+                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,</p>
+                <p>S30,S200,S400,S1275,S5625,</p>
+                <p>C105,C135,C200,C250,C340,C400,C500,C5625,</p>
+                <p>D200,D245,D290,D330,D400,D480,D5625,</p>
+                <p>E30,E80,E135,E145,E250,E290,E320,E330,E400,E460,E495,E1325,E3300,</p>
+                <p>A55,A120,A200,A250,A270,A305,A2950,A3400,</p>
+                <p>W150,W205,W1275,W1375,W1400,W3150,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: Works at e85 gems, updated at e78(?), possibly lower and Angel Lineage 66. Buff Flesh Workshops and Holy Sites. Buff F6000 to 3+ hours. Get A2950 and more expensive research first, fill in the rest to reach 50,000 research points spent as Archon allows you to. Max excavations/resets (this game) to buff C5625. Recast spells from time to time to extend their durations.</p>
+                <p><b>Notes</b>: <b>Do not buy Fairy/Elf/Goblin/Demon/Druid/Faceless/Makers/Djinn heritages/advanced heritages. Do not buy Chaos or Balance researches (i.e. C175, S180, W275, …)</b></p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mercenary Challenge 2</b></a><b><font color="Blue"> Good</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">MCC2 Unlock</b></a><b><font color="Blue"> Good</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e70 (10 Dvg) Gems+</p>
+                <p><b>Author</b>: Rade (assisted by Teraunce)</p>
                 <p><b>Faction</b>: Good/Chaos Mercenary</p>
                 <p><b>Bloodline</b>: Faceless</p>
 				<p><b>D5875</b>: Djinn</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="FR1,FR7,EL3,EL4,EL7,AN12,GB4,TT6,DN2,DN12,DW12,DG7,AR10,DJ3,DJ9,MK5,SP:Fairy Chanting,SP:Hellfire Blast,UB:Swarming Tower,UNN:DN,S400,S1275,C5875,D5875,E50,E135,E3300,A5625,W275,W400,W5125,F5500">
+					<input type="text" value="FR1,FR4,FR7,AN5,AN8,AN12,GB3,GB4,GB6,GB12,UD7,DD10,DN2,DN9,AR10,DJ3,SP:Fairy Chanting,SP:Hellfire Blast,UB:Swarming Tower,UNN:DN,S1,S30,S105,S135,S150,S180,S200,S215,S250,S270,S305,S375,S400,S435,S460,S545,S590,S1275,C10,C25,C80,C5875,D25,D55,D135,D150,D200,D205,D225,D245,D250,D275,D290,D330,D480,D525,D560,D590,D1375,E25,E30,E80,E135,E145,E230,E320,E400,E1325,E3300,A25,A30,A55,A120,A135,A175,A270,A305,A375,A1500,A2950,W25,W135,W150,W175,W180,W250,W275,W290,W400,W1275,W1375,W1400,F5500">
 				</p>
-                <p>FR1,FR7,EL3,EL4,EL7,AN12,GB4,TT6,DN2,DN12,DW12,DG7,AR10,DJ3,DJ9,MK5,</p>
+                <p>FR1,FR4,FR7,AN5,AN8,AN12,GB3,GB4,GB6,GB12,UD7,DD10,DN2,DN9,AR10,DJ3,</p>
                 <p>SP:Fairy Chanting,SP:Hellfire Blast,UB:Swarming Tower,UNN:DN,</p>
-                <p>S400,S1275,</p>
-                <p>C5875,</p>
-                <p>D5875,</p>
-                <p>E50,E135,E3300,</p>
-                <p>A5625,</p>
-                <p>W275,W400,W5125,</p>
+                <p>S1,S30,S105,S135,S150,S180,S200,S215,S250,S270,S305,S375,S400,S435,S460,S545,S590,S1275,</p>
+                <p>C10,C25,C80,C5875,</p>
+                <p>D25,D55,D135,D150,D200,D205,D225,D245,D250,D275,D290,D330,D480,D525,D560,D590,D1375,</p>
+                <p>E25,E30,E80,E135,E145,E230,E320,E400,E1325,E3300,</p>
+                <p>A25,A30,A55,A120,A135,A175,A270,A305,A375,A1500,A2950,</p>
+                <p>W25,W135,W150,W175,W180,W250,W275,W290,W400,W1275,W1375,W1400,</p>
                 <p>F5500</p>
+                <p><b>Notes</b>: Works at e70 gems and faceless lineage as low as 65. Reset brainwave and other spells to increment values tied to spell duration. Buff Ziggurats for DD10</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mercenary Challenge 3</b></a><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">MCC3 Unlock</b></a><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
+                <p><b>Author</b>: Hagio Daemon</p>
+                <p><b>Requirement</b>: 40k max excavations, that can be gotten around 1e90 gems by using R180 Excavation build</p>
                 <p><b>Range</b>: 1e90 (1 Novg) Gems+</p>
                 <p><b>Faction</b>: Good/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Dwarf</p>
+                <p><b>Bloodline</b>: Fairy</p>
 				<p><b>A2950</b>: Dragon</p>
                 <p><b>Artifact Set</b>: Mercenary</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="FR7,AN5,AN12,TT3,DD6,DN2,DW12,AR10,DJ3,SP:Fairy Chanting,SP:Infinite Spiral,UB:High Bastion,S500,S1275,C5875,D275,D290,E135,E3300,A120,A2950,W400">
+					<input type="text" value="FR3,FR10,AN5,AN12,TT9,DD4,DN2,DN9,DW12,AR10,DJ3,MK5,SP:Dragon's Breath,SP:Infinite Spiral,UB:High Bastion,UNN:DG,S180,S400,S500,S1275,C5875,D275,D290,E135,E3300,A30,A120,A270,A2950,W400,W1275,F5500">
 				</p>
-                <p>FR7,AN5,AN12,TT3,DD6,DN2,DW12,AR10,DJ3,</p>
-                <p>SP:Fairy Chanting,SP:Infinite Spiral,UB:High Bastion,</p>
-                <p>S500,S1275,</p>
+                <p>FR3,FR10,AN5,AN12,TT9,DD4,DN2,DN9,DW12,AR10,DJ3,MK5,</p>
+                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:High Bastion,UNN:DG,</p>
+                <p>S180,S400,S500,S1275,</p>
                 <p>C5875,</p>
                 <p>D275,D290,</p>
                 <p>E135,E3300,</p>
-                <p>A120,A2950,</p>
-                <p>W400</p>
-				<p><b>Notes</b>: Do <b>not</b> buy Art of the Crow upgrade.</p>
-				<p><b>Notes</b>: Set up the build, when ready, disable all spells and then cast Share Benefits tiers one by one for the unlock. Cast Fairy Chanting as well if assistant count is too low.</p>
+                <p>A30,A120,A270,A2950,</p>
+                <p>W400,W1275,</p>
+                <p>F5500</p>
+				<p><b>Notes</b>: Cast everything bronze (except share benefits). Cast Share Benefits until you can buy all the upgrades. When ready to go, uncast everything and cast Share Benefits manually until faction chance goes to e12</p>
+				<p><b>Notes</b>: If you are missing Mana Regeneration: Add DD6 or/and cast Dragon Breath tier 5+</p>
+                <p><b>Notes</b>: If you are missing Max Mana : E1325 and DW6, get more Royal Exchanges, buff DJ3 (by buying small researches that don’t affect mana generation/faction find chance)</p>
+                <p><b>Notes</b>: If you are missing assistants : cast fairy chanting</p>
+                <p><b>Notes</b>: Might have have to remove some due to how buffed your run is, this was done without buffing anything (no spells, no assistants, no F6000, no excav reset)</p>
+                <p><b>Notes</b>: <b>Do not buy Art of the Crow upgrade</b></p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mercenary Challenge 4</b></a><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">MCC4 Unlock</b></a><b><font color="Blue"> Good</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e90 (1 Novg) Gems+</p>
+                <p><b>Author</b>: Meirlu</p>
+                <p><b>Requirement</b>: All lineages level 75</p>
                 <p><b>Faction</b>: Good/Balance Mercenary</p>
                 <p><b>Bloodline</b>: Elf</p>
+				<p><b>A2950</b>: Archon</p>
                 <p><b>Artifact Set</b>: Angel</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN6,AN11,GB4,DD3,DN2,DW6,AR4,AR8,AR10,MK1,SP:God's Hand,SP:Infinite Spiral,S400,S1275,S3200,C250,C400,D275,D5375,E135,E320,E3300,A305,A5625,W275,W1375,F5750">
+					<input type="text" value="EL1,EL7,EL8,EL10,EL11,AN5,AN11,GB6,UD7,DD3,DN2,AR8,AR10,MK1,MK5,SP:God's Hand,SP:Infinite Spiral,UB:Arboreal City,S175,S400,S1275,S200,C105,C175,C250,C340,C400,C590,D150,D200,D275,D290,D525,D1375,E135,E320,A2950,A305,W275,W400,W1375">
 				</p>
-                <p>EL1,EL7,EL11,AN6,AN11,GB4,DD3,DN2,DW6,AR4,AR8,AR10,MK1,</p>
-                <p>SP:God's Hand,SP:Infinite Spiral,</p>
-                <p>S400,S1275,S3200,</p>
-                <p>C250,C400,</p>
-                <p>D275,D5375,</p>
-                <p>E135,E320,E3300,</p>
-                <p>A305,A5625,</p>
-                <p>W275,W1375,</p>
-                <p>F5750</p>
-				<p><b>Notes</b>: Requires a short Max Assistants and Spells Cast buffing.</p>
-				<p><b>Notes</b>: Dont buy any upgrade that gives assistants other than Assistant Squasher. Disable Infinite Spiral to complete the challenge.</p>
+                <p>EL1,EL7,EL8,EL10,EL11,AN5,AN11,GB6,UD7,DD3,DN2,AR8,AR10,MK1,MK5,</p>
+                <p>SP:God's Hand,SP:Infinite Spiral,UB:Arboreal City,</p>
+                <p>S175,S400,S1275,S200,</p>
+                <p>C105,C175,C250,C340,C400,C590,</p>
+                <p>D150,D200,D275,D290,D525,D1375,</p>
+                <p>E135,E320,</p>
+                <p>A2950,A305,</p>
+                <p>W275,W400,W1375</p>
+				<p><b>Notes</b>: Buy A2950 before importing, don't buy: R power, challenge power, Holy Crusaders, UD heritage, FR and FC AH, Sun force, makers mask, Individual building upgrades (such as crop rotation for farms) except the Hall of Legends ones. Respec rubies before run if desired, otherwise, don't buy ruby power. Your 1 assistant comes from assistant squasher</p>
+				<p><b>Notes</b>: Buff excav resets, assistants</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Mercenary Challenge 5</b></a><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e110 (100 Qitg) Gems+</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="FR1,EL4,AN12,GB12,UD10,DM9,TT3,DD6,FC7,DN2,DW2,DW6,DG7,AR10,DJ7,MK5,SP:Fairy Chanting,SP:Infinite Spiral,UNN:DW,UNN:DG">
-				</p>
-                <p>FR1,EL4,AN12,GB12,UD10,DM9,TT3,DD6,FC7,DN2,DW2,DW6,DG7,AR10,DJ7,MK5,</p>
-                <p>SP:Fairy Chanting,SP:Infinite Spiral,UNN:DG,UNN:DW,UB:Flesh Workshop</p>
-				<p><b>Notes</b>: Buy the Unique Buildings (Tyrant Garrison (Evil Fortresses) and Flesh Workshop (Orcish Arenas)) <b>After</b> getting as many of these buildings as possible.</p>
-				<p><b>Notes</b>: Buff Excavation Resets (?), Assistants (1e34 (10 Dc)) and F6000.</p>
-				<p><b>Notes</b>: Estimated time is 5-10 minutes.</p>
-            </div>
-        </div>
-    </div>
-	<br/>
-    <p><b>Lineage Builds</b></p>
-    <div class="category">
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R182-R198 Lineage leveler</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">MCC5 Unlock</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e57 (1 Ocd) Gems+</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Any</p>
-                <p><b>A2950</b>: Elf</p>
+                <p><b>Author</b>: Rade</p>
+                <p><b>Faction</b>: Neutral/Chaos Mercenary</p>
+                <p><b>Bloodline</b>: Goblin</p>
                 <p><b>Artifact Set</b>: Faceless</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D200,D275,D290,D330,D3350,E135,E145,E320,E3300,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
+                    <input type="text" value="FR4,EL7,AN12,GB12,UD10,DM11,TT8,DD6,FC2,DN2,DW2,DW6,DG7,AR5,DJ7,MK1,SP:Fairy Chanting,SP:Infinite Spiral,UB:Forbidden Library,UNN:GB,UNN:DN">
 				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Fairy Chanting,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D200,D275,D290,D330,D3350,E135,E145,E320,E3300,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
-					<b>Dragon Lineage</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Dragon's Breath,SP:Precognition,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D200,D275,D290,D330,D3350,E135,E145,E320,E3300,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
-					<b>Makers Lineage</b>
-				</p>
-                <p>EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,</p>
-                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,</p>
-                <p>S200,S5625,</p>
-                <p>C175,C400,C5375,</p>
-                <p>D200,D275,D290,D330,D3350,</p>
-                <p>E135,E145,E320,E3300,</p>
-                <p>A30,A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W275,W400,W1275,W1375,W1400,</p>
-                <p>F5250</p>
-				<p><b>Notes</b>: Do Fairy Lineage first.</p>
-                <p><b>Notes</b>: Buff Clicks, Max Assistants and Excavation resets.</p>
-				<p><b>Notes</b>: For Dragon Lineage, swap Dragon's Breath with Fairy Chanting.</p>
-				<p><b>Notes</b>: For Makers Lineage, swap Infinite Spiral with Precognition.</p>
-				<p><b>Notes</b>: L75 takes about 1 hour with 1e29 (100 Oc) Max Assistants and 50 Excavation Resets.</p>
+                <p>FR4,EL7,AN12,GB12,UD10,DM11,TT8,DD6,FC2,DN2,DW2,DW6,DG7,AR5,DJ7,MK1,</p>
+                <p>SP:Fairy Chanting,SP:Infinite Spiral,UB:Forbidden Library,UNN:GB,UNN:DN</p>
+                <p><b>Notes</b>: Buff Excavation Resets, assistants to at least 100e30, and F6000.</p>
+                <p><b>Notes</b>: Should be able to buy enough buildings and exchanges shortly after buying all upgrades.</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R198-R206 Lineage leveler</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+    </div>
+    <br/>
+    <p><b>Mercenary Duel Unlock (R170)</b></p>
+    <div class="category">
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Clicks</a></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: 1e57 (1 Ocd) Gems+</p>
-				<p><b>Requirements</b>: Mercenary Challenge 3</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Any</p>
-                <p><b>A2950</b>: Elf</p>
-				<p><b>D5875</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Faction</b>: Druid</p>
+                <p><b>Bloodline</b>: Elf</p>
+                <p><b>Artifact Set</b>: Faceless</p>
+                <p><b>Stoneheart Set</b>: Elf</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D5875,E135,E145,E320,E5375,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
+                    <input type="text" value="S200,S400,C250,C340,C400,D200,D275,D290,D330,D1375,E135,E145,E320,E1325,A120,A270,A305,A400,A1325,W400,W1375">
 				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Fairy Chanting,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D5875,E135,E145,E320,E5375,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
-					<b>Dragon Lineage</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,SP:Dragon's Breath,SP:Precognition,UB:Dragon Pasture,UNN:DG,S200,S5625,C175,C400,C5375,D200,D275,D290,D330,D3350,E135,E145,E320,E5375,A30,A120,A250,A270,A305,A545,A1500,A2950,W275,W400,W1275,W1375,W1400,F5250">
-					<b>Makers Lineage</b>
-				</p>
-                <p>EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR10,DJ9,MK1,</p>
-                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Dragon Pasture,UNN:DG,</p>
-                <p>S200,S5625,</p>
-                <p>C175,C400,C5375,</p>
-                <p>D5875,</p>
-                <p>E135,E145,E320,E5375,</p>
-                <p>A30,A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W275,W400,W1275,W1375,W1400,</p>
-                <p>F5250</p>
-				<p><b>Notes</b>: Do Fairy Lineage first.</p>
-                <p><b>Notes</b>: Buff Clicks, Spells, Max Assistants, Excavation resets and F6000.</p>
-				<p><b>Notes</b>: For Dragon Lineage, swap Dragon's Breath with Fairy Chanting.</p>
-				<p><b>Notes</b>: For Makers Lineage, swap Infinite Spiral with Precognition and D5875 with D200,D275,D290,D330,D3350.</p>
-				<p><b>Notes</b>: L90 takes estimated 24-36 hours with 1e34 (10 Dc) Max Assistants, 1e29 (100 Oc) Spells, 100 Excavation Resets and double F6000 buff run (To buff Future Linkin).</p>
+                <p>S200,S400,</p>
+                <p>C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,</p>
+                <p>E135,E145,E320,E1325,</p>
+                <p>A120,A270,A305,A400,A1325,</p>
+                <p>W400,W1375</p>
+                <p><b>Notes</b>: Buff excavations/resets for best results</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Makers Lineage Pusher</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Other Requirements</a></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-				<p><b>Requirements</b>: Mercenary Challenge 5</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Elf</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
+                <p><b>Author</b>: ?</p>
+                <p><b>Faction</b>: Fairy</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Dwarf</p>
                 <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR8,AR10,MK1,SP:Dragon's Breath,SP:Precognition,UB:Dragon Pasture,UNN:DW,UNN:DG,S200,S5625,C175,C400,C5375,D275,D5625,E135,E145,E320,E5375,A55,A270,A305,A545,A1500,A2950,W180,W275,W400,W1275,W1375,W1400,F5250">
+                    <input type="text" value="S30,S180,S200,S330,S400,S500,S545,S590,C105,C250,C340,C400,C520,C1325,D150,D200,D250,D290,D320,D330,D1375,E50,E135,E145,E320,E400,E460,E1325,A30,A55,A105,A120,A150,A250,A270,A305,A400,A495,A545,W135,W1275,W1375">
 				</p>
-                <p>EL1,EL7,EL11,AN5,AN6,AN11,GB4,GB7,DD3,FC2,FC7,DW12,AR5,AR8,AR10,MK1,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Dragon Pasture,UNN:DW,UNN:DG,</p>
-                <p>S200,S5625,</p>
-                <p>C175,C400,C5375,</p>
-                <p>D275,D5625,</p>
-                <p>E135,E145,E320,E5375,</p>
-                <p>A55,A270,A305,A545,A1500,A2950,</p>
-                <p>W180,W275,W400,W1275,W1375,W1400,</p>
-                <p>F5250</p>
-				<p><b>Notes</b>: Run first before other lineages.</p>
-                <p><b>Notes</b>: Buff Clicks, Spells, Assistants, D5625, AR8, Excavations (this R) and Excavation Resets.</p>
-				<p><b>Notes</b>: Estimated time to L100 is (?).</p>
+                <p>S30,S180,S200,S330,S400,S500,S545,S590,</p>
+                <p>C105,C250,C340,C400,C520,C1325,</p>
+                <p>D150,D200,D250,D290,D320,D330,D1375,</p>
+                <p>E50,E135,E145,E320,E400,E460,E1325,</p>
+                <p>A30,A55,A105,A120,A150,A250,A270,A305,A400,A495,A545,</p>
+                <p>W135,W1275,W1375</p>
+                <p><b>Notes</b>: Run this build for ~5 hours after doing the clicks. I was at e46 gems but can probably be done earlier</p>
+                <p><b>Notes</b>: Relies on LW:spell duration increasing DN9. Keep refreshing Brainwave until you have a 800+ day duration. Get a high duration on Fairy Chanting within the first 10 minutes of the run then let the spell run from there, dont recast it.</p>
             </div>
         </div>
-		<div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Lineage leveler</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+    </div>
+    <br/>
+    <p><b>Trophies</b></p>
+    <div class="category">
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Architect</b></a><b><font color="Blue"> Good</font></b>/<b><font color="MediumPurple">Chaos</font></b></p>
             <div class="autohide">
-                <p><b>Author</b>: Ensteffahn</p>
-                <p><b>Range</b>: ?</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Any</p>
-                <p><b>A2950</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-				<p>
+                <p><b>Author</b>: Kabuto44</p>
+                <p><b>Range</b>: 1e131 (100 Dqag) Gems ?</p>
+                <p><b>Faction</b>: Good/Chaos Mercenary</p>
+                <p><b>Bloodline</b>: Archon</p>
+				<p><b>A2950</b>: Goblin</p>
+                <p><b>Artifact Set</b>: Faceless</p>
+                <p>
 					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,AN5,AN6,AN11,AN12,GB7,DD3,DD4,FC2,FC7,DW12,AR5,AR8,AR10,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DW,UNN:DG,S200,S400,S3200,C5875,D275,D5625,E135,E320,E5375,A270,A305,A545,A1500,A2950,W180,W275,W400,W1275,W1375,F5250">
+					<input type="text" value="FR1,DN2,FC3,AR2,AN4,AN5,AR5,GB4,UD7,DW7,DN9,DJ7,UD10,DW12,EL12,AR11,SP:Grand Balance,SP:Infinite Spiral,UNN:DN,UNN:DG,S400,S200,S5125,S1275,C5125,C400,C340,D290,D200,D330,D275,E3300,E135,E50,E230,E5125,A2950,A270,A120,A305,A1500,A545,W275,W1275,W5125,W400,W180,W1375,F5500,F5750">
 				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,AN5,AN6,AN11,AN12,GB7,DD3,DD4,FC2,FC7,DW12,AR5,AR8,AR10,MK1,SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DW,UNN:DG,S200,S400,S3200,S5625,C5875,C250,C340,C400,C590,D275,D5625,D200,D290,D330,E135,E320,E5375,E145,E400,E3300,A270,A305,A545,A1500,A2950,A3400,W180,W275,W400,W1275,W1375,W5625,F5250">
-					<b>Archon Lineage</b>
-				</p>
-				<p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-					<input type="text" value="EL1,EL7,AN5,AN6,AN11,AN12,GB7,DD3,DD4,FC2,FC7,DW12,AR5,AR8,AR10,MK1,SP:Fairy Chanting,SP:Infinite Spiral,UB:Ziggurat,UNN:DW,UNN:DG,S200,S400,S3200,C5875,D275,D5625,E135,E320,E5375,A270,A305,A545,A1500,A2950,W180,W275,W400,W1275,W1375,F5250">
-					<b>Dragon Lineage</b>
-				</p>
-                <p>EL1,EL7,AN5,AN6,AN11,AN12,GB7,DD3,DD4,FC2,FC7,DW12,AR5,AR8,AR10,MK1,</p>
-                <p>SP:Dragon's Breath,SP:Infinite Spiral,UB:Ziggurat,UNN:DW,UNN:DG,</p>
-                <p>S200,S400,S3200,</p>
-                <p>C5875,</p>
-                <p>D275,D5625,</p>
-                <p>E135,E320,E5375,</p>
-                <p>A270,A305,A545,A1500,A2950,</p>
-                <p>W180,W275,W400,W1275,W1375,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: Buff Assistants, Spells, Clicks, Excavations, Resets, D5625, Spell Times, F6000.</p>
-				<p><b>Notes</b>: For Archon Lineage, also select S5625,C250,C340,C400,C590,D200,D290,D330,E145,E400,E3300,A3400,W5625.</p>
-				<p><b>Notes</b>: For Dragon Lineage, swap Dragon's Breath with Fairy Chanting.</p>
+                <p>FR1,DN2,FC3,AR2,AN4,AN5,AR5,GB4,UD7,DW7,DN9,DJ7,UD10,DW12,EL12,AR11,</p>
+                <p>SP:Grand Balance,SP:Infinite Spiral,UNN:DN,UNN:DG,</p>
+                <p>S400,S200,S5125,S1275,</p>
+                <p>C5125,C400,C340,</p>
+                <p>D290,D200,D330,D275,</p>
+                <p>E3300,E135,E50,E230,E5125,</p>
+                <p>A2950,A270,A120,A305,A1500,A545,</p>
+                <p>W275,W1275,W5125,W400,W180,W1375,</p>
+                <p>F5500,F5750</p>
+                <p><b>Notes</b>: 5750 may not be possible</p>
             </div>
         </div>
     </div>

--- a/R160Plus/index.php
+++ b/R160Plus/index.php
@@ -366,6 +366,7 @@
                 <p><b>Notes</b>: Only needs to be run once at some point before A4. Increases combo strike count primarily through DJC1 and Drow challenge reward. <b>DO NOT</b> recast fairy chanting; instead, update its duration by exporting your save and reimporting it. This prevents the DJC1 effect from being reset. Benefits from buffing s5375 and d5625; one strategy is buffing s5375 and d5625 (fairy faction last) at r206 while gaining time for neutral,evil,order, and balance, and running this build for the last day to complete the MCC5 requirement and buff DWP1 simultaneously. Recommended value to aim for is ~300%(?)</p>
             </div>
         </div>
+        <br/>
         <div class="shelementwhole">
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R180+ Mana Produced</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
             <div class="autohide">
@@ -458,32 +459,6 @@
             </div>
         </div>
         <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R206+ Mana Produced + DM2</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Regulus</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Faceless</p>
-                <p><b>A2950</b>: Fairy</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,S200,S400,S5875,C340,C400,C5875,D200,D275,D290,D330,D5625,E135,E145,E5625,A5375,A270,A2950,A30,A120,W275,W400,W1275,W5625,F5250">
-				</p>
-                <p>AN4,AN5,AN8,AN12,DM2,GB6,UD7,DD10,DD11,FC3,DN2,DN9,AR12,DJ3,DJ5,DJ7,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Flesh Workshop,UNN:AR,UNN:DW,</p>
-                <p>S200,S400,S5875,</p>
-                <p>C340,C400,C5875,</p>
-                <p>D200,D275,D290,D330,D5625,</p>
-                <p>E135,E145,E5625,</p>
-                <p>A5375,A270,A2950,A30,A120,</p>
-                <p>W275,W400,W1275,W5625,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: Needs some F6000 to be able to afford A researches</p>
-                <p><b>Notes</b>: After buying these researches, get stuff for prod/dj3</p>
-                <p><b>Notes</b>: Reached 3e24(7e24 w/ gem grinder) MM in 30 min, done at 23h F6000</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">High Mana Produced (R219?)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
             <div class="autohide">
                 <p><b>Author</b>: Regulus</p>
@@ -509,6 +484,7 @@
                 <p><b>Notes</b>: Should be able to reach up to 1e26 Max mana</p>
             </div>
         </div>
+        <br/>
         <div class="shelementwhole">
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">R180+ Excavation Resets</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
@@ -606,6 +582,7 @@
                 <p><b>Notes</b>: At coin cap: DJ7->DJ9, DJ3->DM2, GB4->GB6, S researches->S5875?, F5750->F5250 if you have offline time. If you can still reach cap: Grand balance-> moon blessing</p>
             </div>
         </div>
+        <br/>
         <div class="shelementwhole">
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">F6000 Buff (R182-R190)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
             <div class="autohide">
@@ -657,6 +634,140 @@
                 <p><b>Notes</b>: Buy E3300 only when you're ready to abdicate. E3300 tanks the production of the build but massively boosts F6000. Buy any buildings that E3300 provides with the building cost reduction, refresh all spells and then abdicate.</p>
             </div>
         </div>
+        <br/>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R190+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Kabuto44, based on a build by Meirlu</p>
+                <p><b>Requirement</b>: MCC1</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Fairy</p>
+                <p><b>A2950</b>: Faceless</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,S200,S400,S5875,S180,C5875,C175,C250,C340,C400,D200,D275,D290,D330,D1375,D5625,E3300,E135,E5125,E400,E495,E145,A2950,A270,A5375,W5625,W1275,W275,W400,W1375,W205,F5250">
+				</p>
+                <p>AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,</p>
+                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,</p>
+                <p>S200,S400,S5875,S180,</p>
+                <p>C5875,C175,C250,C340,C400,</p>
+                <p>D200,D275,D290,D330,D1375,D5625,</p>
+                <p>E3300,E135,E5125,E400,E495,E145,</p>
+                <p>A2950,A270,A5375,</p>
+                <p>W5625,W1275,W275,W400,W1375,W205,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: After A5375: A30,A120,A305,A250,A1500</p>
+                <p><b>Notes</b>: Recommended F6000 16h? to buy A5375</p>
+            </div>
+        </div>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R198+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Gull</p>
+                <p><b>Requirement</b>: MCC3</p>
+                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Makers</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,S30,S5875,C5875,C105,D290,D5625,D55,D25,E135,E400,E5375,E30,E25,A30,A120,A270,A305,A545,A1500,A2950,A250,W180,W275,W400,W1275,W1375,W150,W175,W200,W250,F5250">
+				</p>
+                <p>EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,</p>
+                <p>S30,S5875,</p>
+                <p>C5875,C105,</p>
+                <p>D290,D5625,D55,D25,</p>
+                <p>E135,E400,E5375,E30,E25,</p>
+                <p>A30,A120,A270,A305,A545,A1500,A2950,A250,</p>
+                <p>W180,W275,W400,W1275,W1375,W150,W175,W200,W250,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Run multiple times to buff assistants more. Benefits from f6000  and mana produced. Recast Fairy Chanting to increase DN9.</p>
+            </div>
+        </div>
+        <br/>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Mana Regen (R202+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Regulus</p>
+                <p><b>Faction</b>: Evil/Order Mercenary</p>
+                <p><b>Bloodline</b>: Faceless</p>
+                <p><b>A2950</b>: Fairy</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,S200,S3200,S5625,C250,C340,C400,C590,C5875,D200,D275,D290,D330,D5625,E135,E320,E3300,E5625,A5375,A270,A2950,A30,A120,A545,W1275,W5625,W275,W400,W1375,W205,F5250">
+				</p>
+                <p>FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,</p>
+                <p>SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,</p>
+                <p>S200,S3200,S5625,</p>
+                <p>C250,C340,C400,C590,C5875,</p>
+                <p>D200,D275,D290,D330,D5625,</p>
+                <p>E135,E320,E3300,E5625,</p>
+                <p>A5375,A270,A2950,A30,A120,A545,</p>
+                <p>W1275,W5625,W275,W400,W1375,W205,</p>
+                <p>F5250</p>
+                <p><b>Notes</b>: Tested after MCC5, with ~6h this R/3h evil</p>
+                <p><b>Notes</b>: buff FR12 (titanline fairy is good enough, but can get a couple OoM more with a specific faceline fairy build (recommend for like 202-206)) and Mana produced, let grow until Catalyst hits Gem Grinder for maximum gains.</p>
+            </div>
+        </div>
+        <br/>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Clicks (R202+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Miracle Man0</p>
+                <p><b>Requirement</b>: 1e95 (100 Tg) Gems + (the more the better), MCC4</p>
+                <p><b>Faction</b>: Neutral/Order Mercenary</p>
+                <p><b>Bloodline</b>: Djinn</p>
+                <p><b>A2950</b>: Elf</p>
+                <p><b>Artifact Set</b>: Elf</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,S180,S200,S400,S5875,C175,C340,C400,C590,C5375,D200,D275,D290,D330,D1375,E145,E320,E5625,A120,A250,A270,A305,A545,A1500,A2950,W175,W180,W275,W400,W1275,W1375,W1400,F5500">
+				</p>
+                <p>EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,</p>
+                <p>SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,</p>
+                <p>S180,S200,S400,S5875,</p>
+                <p>C175,C340,C400,C590,C5375,</p>
+                <p>D200,D275,D290,D330,D1375,</p>
+                <p>E145,E320,E5625,</p>
+                <p>A120,A250,A270,A305,A545,A1500,A2950,</p>
+                <p>W175,W180,W275,W400,W1275,W1375,W1400,</p>
+                <p>F5500</p>
+                <p><b>Notes</b>: Neutral is used for C5375, order is used for makersline and all other bloodlines. Djinn lineage used for the perk to give autoclicks to LW. Elf A2950 for autoclicks.Once you buy all upgrades, speed of reaching God's Fingers depends on previous buffs which allow you to accumulate faction coins and boost the makerline power. Benefits from buffing max assistants (W275), excavations and resets (IS), max number of labyrinths (FC2), spells cast (S400). Running this at end of R gems is better as you boost DW12, will be able to afford more buildings (DW7), and likely will have boosted TTC4 earlier in the R as well. Since you have archonline, benefits from F6000 buffs, untested, may let you buy A3400, which is probably better than i.e. A545.</p>
+                <p><b>Notes</b>: Tested relatively unbuffed at 4e93 gems, took 100-110 hours to god's fingers, but I spent some time offline and lost LW autoclicks. With buffs I estimate God's Fingers in under 100 hours, perhaps as low as 3.5 days.</p>
+            </div>
+        </div>
+        <br/>
+        <div class="shelementwhole">
+            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Flesh Workshops and Brothels Buff (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
+            <div class="autohide">
+                <p><b>Author</b>: Rade</p>
+                <p><b>Faction</b>: Evil/Balance Mercenary</p>
+                <p><b>Bloodline</b>: Goblin</p>
+                <p><b>A2950</b>: Makers</p>
+                <p><b>Artifact Set</b>: Mercenary</p>
+                <p>
+					<button onclick="myFunction($(this))">Copy Build</button>
+                    <input type="text" value="AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S30,S150,S180,S200,S215,S5125,C25,C105,C340,C400,C5125,D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,E30,E80,E135,E230,E400,E5125,A30,A105,A120,A150,A270,A305,A545,A1500,A2950,W180,W275,W400,W5125,F5750">
+				</p>
+                <p>AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,</p>
+                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,</p>
+                <p>S30,S150,S180,S200,S215,S5125,</p>
+                <p>C25,C105,C340,C400,C5125,</p>
+                <p>D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,</p>
+                <p>E30,E80,E135,E230,E400,E5125,</p>
+                <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
+                <p>W180,W275,W400,W5125,</p>
+                <p>F5750</p>
+                <p><b>Notes</b>: For buffing brothels switch Flesh Workshop->Brothel and AN4->FR4</p>
+            </div>
+        </div>
+    </div>
+    <br/>
+    <p><b>Lineage Builds</b></p>
+    <div class="category">
         <div class="shelementwhole">
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Lineage Leveler (R180-R193)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
             <div class="autohide">
@@ -756,132 +867,6 @@
                 <p>F5500</p>
                 <p><b>Notes</b>: Replace Titan Union with Drow Union if F6000 is less than ~80 hours. EL11 may provide more benefit than whichever is lower between UD10 and DW12. Switch DN9->AR8 if activity time over 8? hours? Optimized for R206+, but can still quickly produce 75+ lineages with MCC3 and no F6000. Level Druid lineage first. May require slight changes for other lineages. Can reach l95 in 1 hour, potentially l96 with the following buffs (try to line up with mcc5/god’s fingers to preserve buffs) Makerline with Elf A2950 may also work well as first.</p>
                 <p><b>Notes</b>: 4 day F6000, buff future linkin with double f6000 if desired. 19 h Fairy time. 5e26 spells. 2.5e39 assistants. 1e8 clicks this R. 0 h d5625 (can buff if desired during mcc5 waiting period). 100 Excavation Resets. Also buff max. Mountain palaces, flesh workshops, labyrinths. Try to buff activity time on spells during waiting period as well to speed up lineage leveling.</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R190+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Kabuto44, based on a build by Meirlu</p>
-                <p><b>Requirement</b>: MCC1</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Fairy</p>
-                <p><b>A2950</b>: Faceless</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,S200,S400,S5875,S180,C5875,C175,C250,C340,C400,D200,D275,D290,D330,D1375,D5625,E3300,E135,E5125,E400,E495,E145,A2950,A270,A5375,W5625,W1275,W275,W400,W1375,W205,F5250">
-				</p>
-                <p>AN4,DM2,GB4,DW7,GB6,UD7,UD10,DD10,DD11,FC3,DN2,DN9,AR2,AR12,DJ5,DJ7,</p>
-                <p>SP:Dragon's Breath,SP:Precognition,UB:Flesh Workshop,UNN:AR,</p>
-                <p>S200,S400,S5875,S180,</p>
-                <p>C5875,C175,C250,C340,C400,</p>
-                <p>D200,D275,D290,D330,D1375,D5625,</p>
-                <p>E3300,E135,E5125,E400,E495,E145,</p>
-                <p>A2950,A270,A5375,</p>
-                <p>W5625,W1275,W275,W400,W1375,W205,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: After A5375: A30,A120,A305,A250,A1500</p>
-                <p><b>Notes</b>: Recommended F6000 16h? to buy A5375</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Assistants Buff (R198+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Gull</p>
-                <p><b>Requirement</b>: MCC3</p>
-                <p><b>Faction</b>: Neutral/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Makers</p>
-                <p><b>A2950</b>: Fairy</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,S30,S5875,C5875,C105,D290,D5625,D55,D25,E135,E400,E5375,E30,E25,A30,A120,A270,A305,A545,A1500,A2950,A250,W180,W275,W400,W1275,W1375,W150,W175,W200,W250,F5250">
-				</p>
-                <p>EL12,AN4,AN5,UD7,UD10,DD6,FC2,FC3,DN2,DN9,DW7,DW10,DW12,AR2,DJ9,MK6,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Dragon Pasture,UNN:DG,UNN:DW,</p>
-                <p>S30,S5875,</p>
-                <p>C5875,C105,</p>
-                <p>D290,D5625,D55,D25,</p>
-                <p>E135,E400,E5375,E30,E25,</p>
-                <p>A30,A120,A270,A305,A545,A1500,A2950,A250,</p>
-                <p>W180,W275,W400,W1275,W1375,W150,W175,W200,W250,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: Run multiple times to buff assistants more. Benefits from f6000  and mana produced. Recast Fairy Chanting to increase DN9.</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Mana Regen (R202+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Regulus</p>
-                <p><b>Faction</b>: Evil/Order Mercenary</p>
-                <p><b>Bloodline</b>: Faceless</p>
-                <p><b>A2950</b>: Fairy</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,S200,S3200,S5625,C250,C340,C400,C590,C5875,D200,D275,D290,D330,D5625,E135,E320,E3300,E5625,A5375,A270,A2950,A30,A120,A545,W1275,W5625,W275,W400,W1375,W205,F5250">
-				</p>
-                <p>FR12,GB5,GB6,UD7,DM2,TT2,DD10,DD11,FC3,DN4,DN9,DW7,DJ3,AR12,DJ5,DJ7,</p>
-                <p>SP:Fairy Chanting,SP:Precognition,UB:Brothel,UNN:AR,UNN:AN,</p>
-                <p>S200,S3200,S5625,</p>
-                <p>C250,C340,C400,C590,C5875,</p>
-                <p>D200,D275,D290,D330,D5625,</p>
-                <p>E135,E320,E3300,E5625,</p>
-                <p>A5375,A270,A2950,A30,A120,A545,</p>
-                <p>W1275,W5625,W275,W400,W1375,W205,</p>
-                <p>F5250</p>
-                <p><b>Notes</b>: Tested after MCC5, with ~6h this R/3h evil</p>
-                <p><b>Notes</b>: buff FR12 (titanline fairy is good enough, but can get a couple OoM more with a specific faceline fairy build (recommend for like 202-206)) and Mana produced, let grow until Catalyst hits Gem Grinder for maximum gains.</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Clicks (R202+)</a></b><b><font color="darkgoldenrod"> Neutral</font></b>/<b><font color="MediumTurquoise">Order</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Miracle Man0</p>
-                <p><b>Requirement</b>: 1e95 (100 Tg) Gems + (the more the better), MCC4</p>
-                <p><b>Faction</b>: Neutral/Order Mercenary</p>
-                <p><b>Bloodline</b>: Djinn</p>
-                <p><b>A2950</b>: Elf</p>
-                <p><b>Artifact Set</b>: Elf</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,S180,S200,S400,S5875,C175,C340,C400,C590,C5375,D200,D275,D290,D330,D1375,E145,E320,E5625,A120,A250,A270,A305,A545,A1500,A2950,W175,W180,W275,W400,W1275,W1375,W1400,F5500">
-				</p>
-                <p>EL1,EL7,EL11,AN5,AN6,AN12,GB4,GB7,DD3,FC2,DW7,DW12,AR5,AR10,DJ9,MK1,</p>
-                <p>SP:Moon Blessing,SP:Infinite Spiral,UB:Dragon Pasture,UNN:EL,UNN:GB,</p>
-                <p>S180,S200,S400,S5875,</p>
-                <p>C175,C340,C400,C590,C5375,</p>
-                <p>D200,D275,D290,D330,D1375,</p>
-                <p>E145,E320,E5625,</p>
-                <p>A120,A250,A270,A305,A545,A1500,A2950,</p>
-                <p>W175,W180,W275,W400,W1275,W1375,W1400,</p>
-                <p>F5500</p>
-                <p><b>Notes</b>: Neutral is used for C5375, order is used for makersline and all other bloodlines. Djinn lineage used for the perk to give autoclicks to LW. Elf A2950 for autoclicks.Once you buy all upgrades, speed of reaching God's Fingers depends on previous buffs which allow you to accumulate faction coins and boost the makerline power. Benefits from buffing max assistants (W275), excavations and resets (IS), max number of labyrinths (FC2), spells cast (S400). Running this at end of R gems is better as you boost DW12, will be able to afford more buildings (DW7), and likely will have boosted TTC4 earlier in the R as well. Since you have archonline, benefits from F6000 buffs, untested, may let you buy A3400, which is probably better than i.e. A545.</p>
-                <p><b>Notes</b>: Tested relatively unbuffed at 4e93 gems, took 100-110 hours to god's fingers, but I spent some time offline and lost LW autoclicks. With buffs I estimate God's Fingers in under 100 hours, perhaps as low as 3.5 days.</p>
-            </div>
-        </div>
-        <div class="shelementwhole">
-            <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Max Flesh Workshops and Brothels Buff (R206+)</a></b><b><font color="darkred"> Evil</font></b>/<b><font color="gray">Balance</font></b></p>
-            <div class="autohide">
-                <p><b>Author</b>: Rade</p>
-                <p><b>Faction</b>: Evil/Balance Mercenary</p>
-                <p><b>Bloodline</b>: Goblin</p>
-                <p><b>A2950</b>: Makers</p>
-                <p><b>Artifact Set</b>: Mercenary</p>
-                <p>
-					<button onclick="myFunction($(this))">Copy Build</button>
-                    <input type="text" value="AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,S30,S150,S180,S200,S215,S5125,C25,C105,C340,C400,C5125,D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,E30,E80,E135,E230,E400,E5125,A30,A105,A120,A150,A270,A305,A545,A1500,A2950,W180,W275,W400,W5125,F5750">
-				</p>
-                <p>AN4,AN5,GB3,GB6,UD7,UD10,FC3,DN2,DW7,DW8,DW10,DW12,AR2,AR12,DJ7,MK6,</p>
-                <p>SP:Grand Balance,SP:Precognition,UB:Flesh Workshop,UNN:DW,UNN:DG,</p>
-                <p>S30,S150,S180,S200,S215,S5125,</p>
-                <p>C25,C105,C340,C400,C5125,</p>
-                <p>D25,D55,D135,D200,D245,D250,D275,D290,D320,D330,D560,D590,D1275,D1375,</p>
-                <p>E30,E80,E135,E230,E400,E5125,</p>
-                <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
-                <p>W180,W275,W400,W5125,</p>
-                <p>F5750</p>
-                <p><b>Notes</b>: For buffing brothels switch Flesh Workshop->Brothel and AN4->FR4</p>
             </div>
         </div>
     </div>

--- a/scripts/header.html
+++ b/scripts/header.html
@@ -16,7 +16,7 @@
         padding: 3px;
         }
         .Faction td {
-            font-weight: bold
+            font-weight: bold;
         padding: 10px;
         }
        .gsc-cursor-page  {
@@ -308,7 +308,7 @@
                     <li id="active"><a href="/realm/R125Plus" research="Elite Factions">R125-R135 Builds <span style="color:red">(Currently Outdated)</span></a></li>
                     <li id="active"><a href="/realm/R135Plus" research="Elite Challenges">R135-R159 Builds</a></li>
 					<li id="active"><a target="_blank" research="R160+ Guide" href="/realm/A3_Plot.png">A3 Plot <span style="color:blue">(Currently Outdated)</span></a></li>
-                    <li id="active"><a href="/realm/R160Plus" research="A3 Mercenaries">R160+ Builds <span style="color:red">(Currently Outdated)</span></a></li>
+                    <li id="active"><a href="/realm/R160Plus" research="A3 Mercenaries">R160+ Builds</a></li>
 
                     </ul>
                     </div>


### PR DESCRIPTION
Replace all builds in R160+ section with builds from the Google doc pinned in the Discord. Remove "outdated" indicators.