### PR TITLE
Add spellcheck action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,16 @@
+name: "spellcheck"
+on: ["push", "pull_request"]
+
+jobs:
+  spellcheck:
+    name: "spellcheck"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "obtain source code"
+        uses: "actions/checkout@v2"
+      - name: "run codespell"
+        uses: "codespell-project/actions-codespell@master"
+        with:
+          check_filenames: true
+          skip: "./WallofShame/index.php"
+          ignore_words_list: "sting,fanatism,restauration,ded,rade,gud,nd,calss"


### PR DESCRIPTION
In #330 I used [codespell](https://github.com/codespell-project/codespell/) to find and correct as many spelling mistakes as I could. They also provide a [GitHub action](https://github.com/codespell-project/actions-codespell/) that will automatically search for spelling mistakes on every commit and pull request. This pull request adds that action to this repository.

I have made some opinionated choices when setting up this action, please feel free to let me know if you want anything done differently:
 * The action allows two ways for configuration: you can specify it in the action itself, or use a `.codespellrc` file. I felt it was cleaner to consolidate everything into the action instead of creating a separate configuration file.
 * I've set up the action to check file names for spelling mistakes as well. This isn't the default behavior, but I believe it's helpful.
 * The `./WallofShame/index.php` file is full of many spelling mistakes that are intentional (as part of user-provided content). However those spelling mistakes would be a problem if present in other files. Because of that, I've set up the action to entirely ignore that one file.
 * This spell-checker has a few false positives, I've chosen to simply whitelist them. It's also possible to change which dictionaries are used by the spell-checker, however I believe it's better to have a larger list along with a whitelist for exceptions instead of a smaller list that risks missing spelling mistakes entirely.
 * The action provides a setting that warns when spelling mistakes are found, instead of erroring. This can be useful if you wish to note spelling mistakes but not block pull requests because of them, but I haven't enabled it because I prefer strictness.