### PR TITLE
Note cleanup

### DIFF
--- a/3.5Patch/index.php
+++ b/3.5Patch/index.php
@@ -202,7 +202,7 @@
                     <p><b>Requirements</b>: R130+</p>
                     <p><b>Effect</b>: Gain a new spell that costs 500,000 mana and lasts 1 minute as a fixed duration. Each time you cast it, it activates a vanilla or primary alignment spell at tier 7.</p>
                     <p><b><img src="http://musicfamily.org/realm/Factions/picks/CatalystSpell.png"></b></p>
-                    <p><b>Notes</b></p>
+                    <p><b>Note</b></p>
                     <p><b>1</b>. Spell comes with tier bonus.</p>
                     <p><b>2</b>. Choosing this Bloodline or having/buying A400 with Djinn gives you the vanilla spell upgrades that enable the challenge reward when bought.</p>
                     <p><b>3</b>. Cannot cast a spell that is already active</p>

--- a/Artifacts/index.php
+++ b/Artifacts/index.php
@@ -30,7 +30,7 @@
 		   - A1+: (1 + (0.2 - C) / (5 * A)), where C is the sum of your flat cost reduction upgrades and A is your Ascension.</p>
 		<p>Every time you excavate, you have a 35% (40% with 'That Excavated Quickly' upgrade) chance per excavation to find a certain amount of Faction Coins as reward.</p>
         <p><b>Faction Coin Reward Formula</b>: (1500 + 0.05 * (x-1) ^ 2.75), where x is the number of excavations you have.</p>
-		<p></b>Note: Every time you reincarnate or ascend, your excavation counter will be set back to zero.</p>
+		<p><b>Note</b>: Every time you reincarnate or ascend, your excavation counter will be set back to zero.</p>
         <hr>
 		<p><b>Excavation Reset</b></p>
 		<p>To be able to do more excavations within a Reincarnation you can do an Excavation Reset, which also sets the counter back to zero. There are two options:<br>Ruby Reset and Free Reset.</p>

--- a/Bloodline/index.php
+++ b/Bloodline/index.php
@@ -172,7 +172,7 @@
 		<p><b>Effect</b>: Activates a random vanilla or base alignment spell at tier 7 for 60 seconds. This spell's duration cannot be modified.</p>
 		<p><b>Note</b>: Can not access Holy Frenzy regardless of alignment.</p>
 		<p><b>Requirements</b>: R130+, Djinn Bloodline</p>
-		<p><b>Notes</b></p>
+		<p><b>Note</b></p>
 		<p><b>1</b>. Choosing this Bloodline or having/buying A400 with Djinn gives you the vanilla spell upgrades that enable the challenge reward when bought.</p>
 		<p><b>2</b>. Cannot cast a spell that is already available.</p>
 		<p><b>3</b>. The Spell Pool is 8 for Neutral factions, 7 for Good/Evil (-1 faction and -1 alignment spell)</p>

--- a/Changelog/index.php
+++ b/Changelog/index.php
@@ -1501,7 +1501,7 @@
             <p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">v1.6.51, Apr 1, 2016, April Fools joke</a></b></p>
             <div class="autohide">
                 <p><b>Patch</b>: 1.6.51 - April 1 2016</p>
-                <p>Added a new secret upgrade. (NOTE: This upgrade no longer exists as it was only an April Fools joke!)</p>
+                <p>Added a new secret upgrade. (Note: This upgrade no longer exists as it was only an April Fools joke!)</p>
                 <p>Fixed an issue that caused Drow assistant to crawl on the game screen.</p>
             </div>
         </div>

--- a/Events/index.php
+++ b/Events/index.php
@@ -988,7 +988,7 @@
                         <p><b>Effect</b>: Grants All Creation spell with a cost of 1000 mana.</p>
                         <p><img src="/realm/Factions/picks/AllCreation1000.png" align="middle"></p>
                         <p><b>Effect</b>: Increase production of all buildings based on your Mana Regeneration.</p>
-                        <p><b>Formula</b>: (0.15 * ln(1 + x) ^ 3.5 + 0.9 * x ^ 0.27)%, where x is your Mana Regeneration.</p>						
+                        <p><b>Formula</b>: (0.15 * ln(1 + x) ^ 3.5 + 0.9 * x ^ 0.27)%, where x is your Mana Regeneration.</p>
                         <p><b>Effect</b>: Also multiplicative increase Faction Coin find chance based on your Mana Regeneration.</p>
                         <p><b>Formula</b>: (5 * ln(1 + x) ^ 2.5 + 15 * x ^ 0.15)%, where x is your Mana Regeneration.</p>
                         <p><b>Note</b>: All Creation obtained this way cannot be tiered.</p>
@@ -1658,8 +1658,8 @@
                         <p><b>Kind</b>: Upgrade</p>
                         <p><b>Unlock / Price</b>: 1 Coin</p>
                         <p><b>Effect</b>: Increase the production of all buildings by 1e6%.</p>
-                        <p><b>Notes</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
-                        <p><b>Notes</b>: This upgrade does nothing.</p>
+                        <p><b>Note</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
+                        <p><b>Note</b>: This upgrade does nothing.</p>
                     </div>
                 </div>
                 <div class="shelementwhole">
@@ -1763,7 +1763,7 @@
                         <p>It's Christmas time! The subjects of your Realm are sensing the aura of power in the air, inspiring them in their daily life and making them feel proud of your righteous leadership. Encouraged by your unmatched abilities as a ruler, they believed it would be appropriate to offer you a daily tribute for the duration of the Holidays.</p>
                         <p><b>Event Theme</b>: Snowballs. They will accumulate at a rate of 1 per minute, up to a maximum of 720 (12 hours). Collecting Snowballs will allow you to complete quests and increase your Avalanche upgrade bonus.</p>
                         <p>Every day you will receive a Christmas Present containing Snowballs or Rubies. Presents are required to complete quests and can only be retrieved once per day by going online.</p>
-                        <p><b>Notes</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
+                        <p><b>Note</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
                         <p><b>Event Bonus</b>: Total cumulative and permanent quest bonus at the end of the Event: 14%</p>
                         <p><b>Note</b>: If you didn't unlock all the Christmas feats last year, you have a chance to do so with this one! If you already did, you will be able to gain additional permanent production bonuses from completing all the quests again, and benefit from the massive bonus from the Avalanche upgrade once again.</p>
                         <p>You can find all this information in a guide by pressing the "?" button in the Event Panel.</p>
@@ -2930,8 +2930,8 @@
                         <p><b>Kind</b>: Upgrade</p>
                         <p><b>Unlock / Price</b>: 1 Coin</p>
                         <p><b>Effect</b>: Increase the production of all buildings by 1e6%.</p>
-                        <p><b>Notes</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
-                        <p><b>Notes</b>: This upgrade does nothing.</p>
+                        <p><b>Note</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
+                        <p><b>Note</b>: This upgrade does nothing.</p>
                     </div>
                 </div>
                 <div class="shelementwhole">
@@ -3028,7 +3028,7 @@
                         <p>It's Christmas time! The subjects of your Realm are sensing the aura of power in the air, inspiring them in their daily life and making them feel proud of your righteous leadership. Encouraged by your unmatched abilities as a ruler, they believed it would be appropriate to offer you a daily tribute for the duration of the Holidays.</p>
                         <p><b>Event Theme</b>: Snowballs. They will accumulate at a rate of 1 per minute, up to a maximum of 720 (12 hours). Collecting Snowballs will allow you to complete quests and increase your Avalanche upgrade bonus.</p>
                         <p>Every day you will receive a Christmas Present containing Snowballs or Rubies. Presents are required to complete quests and can only be retrieved once per day by going online.</p>
-                        <p><b>Notes</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
+                        <p><b>Note</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
                         <p><b>Event Bonus</b>: Total cumulative and permanent quest bonus at the end of the Event: 14%</p>
                         <p><b>Note</b>: If you didn't unlock all the Christmas feats last year, you have a chance to do so with this one! If you already did, you will be able to gain additional permanent production bonuses from completing all the quests again, and benefit from the massive bonus from the Avalanche upgrade once again.</p>
                         <p>You can find all this information in a guide by pressing the "?" button in the Event Panel.</p>
@@ -3997,13 +3997,13 @@
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 3000 Common Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 3000 Common Eggs for 1 Unique Egg.</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b><img src="/realm/Factions/picks/BuyUnique100Easter2017.png" alt="Buy Unique Egg" align="middle"> Buy Unique Egg</b></p>
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 100 Rare Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 100 Rare Eggs for 1 Unique Egg</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b>Egg Hunter Quest</b></p>
                         <p><b>Note</b>: Each Quest step will increase your Event bonus, which will be added to your Cumulative Event bonus. (Total: 7%)</p>
@@ -4148,8 +4148,8 @@
                         <p><b>Kind</b>: Upgrade</p>
                         <p><b>Unlock / Price</b>: 1 Coin</p>
                         <p><b>Effect</b>: Increase the production of all buildings by 1e6%.</p>
-                        <p><b>Notes</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
-                        <p><b>Notes</b>: This upgrade does nothing.</p>
+                        <p><b>Note</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
+                        <p><b>Note</b>: This upgrade does nothing.</p>
                     </div>
                 </div>
                 <div class="shelementwhole">
@@ -4243,7 +4243,7 @@
                         <p>It's Christmas time! The subjects of your Realm are sensing the aura of power in the air, inspiring them in their daily life and making them feel proud of your righteous leadership. Encouraged by your unmatched abilities as a ruler, they believed it would be appropriate to offer you a daily tribute for the duration of the Holidays.</p>
                         <p><b>Event Theme</b>: Snowballs. They will accumulate at a rate of 1 per minute, up to a maximum of 720 (12 hours). Collecting Snowballs will allow you to complete quests and increase your Avalanche upgrade bonus.</p>
                         <p>Every day you will receive a Christmas Present containing Snowballs or Rubies. Presents are required to complete quests and can only be retrieved once per day by going online.</p>
-                        <p><b>Notes</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
+                        <p><b>Note</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
                         <p><b>Event Bonus</b>: Total cumulative and permanent quest bonus at the end of the Event: 14%</p>
                         <p><b>Note</b>: If you didn't unlock all the Christmas feats last year, you have a chance to do so with this one! If you already did, you will be able to gain additional permanent production bonuses from completing all the quests again, and benefit from the massive bonus from the Avalanche upgrade once again.</p>
                         <p>You can find all this information in a guide by pressing the "?" button in the Event Panel.</p>
@@ -4967,13 +4967,13 @@
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 3000 Common Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 3000 Common Eggs for 1 Unique Egg.</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b><img src="/realm/Factions/picks/BuyUnique100Easter2017.png" alt="Buy Unique Egg" align="middle"> Buy Unique Egg</b></p>
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 100 Rare Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 100 Rare Eggs for 1 Unique Egg</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b>Egg Hunter Quest</b></p>
                         <p><b>Note</b>: Each Quest step will increase your Event bonus, which will be added to your Cumulative Event bonus. (Total: 7%)</p>
@@ -5111,8 +5111,8 @@
                         <p><b>Kind</b>: Upgrade</p>
                         <p><b>Unlock / Price</b>: 1 Coin</p>
                         <p><b>Effect</b>: Increase the production of all buildings by 1e6%.</p>
-                        <p><b>Notes</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
-                        <p><b>Notes</b>: This upgrade does nothing.</p>
+                        <p><b>Note</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
+                        <p><b>Note</b>: This upgrade does nothing.</p>
                     </div>
                 </div>
                 <div class="shelementwhole">
@@ -5189,7 +5189,7 @@
                         <p>It's Christmas time! The subjects of your Realm are sensing the aura of power in the air, inspiring them in their daily life and making them feel proud of your righteous leadership. Encouraged by your unmatched abilities as a ruler, they believed it would be appropriate to offer you a daily tribute for the duration of the Holidays.</p>
                         <p><b>Event Theme</b>: Snowballs. They will accumulate at a rate of 1 per minute, up to a maximum of 480 (8 hours). Collecting Snowballs will allow you to complete quests and increase your Avalanche upgrade bonus.</p>
                         <p>Every day you will receive a Christmas Present containing Snowballs or Rubies. Presents are required to complete quests and can only be retrieved once per day by going online.</p>
-                        <p><b>Notes</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
+                        <p><b>Note</b>: The daily Christmas presents contains 1 Ruby or 200 Snowballs (every other present)</p>
                         <p><b>Event Bonus</b>: Total cumulative and permanent quest bonus at the end of the Event: 14%</p>
                         <p><b>Note</b>: If you didn't unlock all the Christmas feats last year, you have a chance to do so with this one! If you already did, you will be able to gain additional permanent production bonuses from completing all the quests again, and benefit from the massive bonus from the Avalanche upgrade once again.</p>
                         <p>You can find all this information in a guide by pressing the "?" button in the Event Panel.</p>
@@ -5825,13 +5825,13 @@
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 3000 Common Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 3000 Common Eggs for 1 Unique Egg.</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b><img src="/realm/Factions/picks/BuyUnique100Easter2017.png" alt="Buy Unique Egg" align="middle"> Buy Unique Egg</b></p>
                         <p><b>Kind</b>: Converter</p>
                         <p><b>Unlock / Price</b>: 100 Rare Eggs</p>
                         <p><b>Effect & Notes</b>: Exchange 100 Rare Eggs for 1 Unique Egg</p>
-                        <p><b>Notes</b>: This disappears after you get your last Unique Egg.</p>
+                        <p><b>Note</b>: This disappears after you get your last Unique Egg.</p>
                         <hr>
                         <p><b>Egg Hunter Quest</b></p>
                         <p><b>Note</b>: Each Quest step will increase your Event bonus, which will be added to your Cumulative Event bonus. (Total: 7%)</p>
@@ -5941,8 +5941,8 @@
                         <p><b>Kind</b>: Upgrade</p>
                         <p><b>Unlock / Price</b>: 1 Coin</p>
                         <p><b>Effect</b>: Increase the production of all buildings by 1e6%.</p>
-                        <p><b>Notes</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
-                        <p><b>Notes</b>: This upgrade does nothing.</p>
+                        <p><b>Note</b>: If you got this upgrade in the past it will only show in purchased upgrades.</p>
+                        <p><b>Note</b>: This upgrade does nothing.</p>
                     </div>
                 </div>
                 <div class="shelementwhole">
@@ -6012,7 +6012,7 @@
                         <p>It's Christmas time! The subjects of your Realm are sensing the aura of power in the air, inspiring them in their daily life and making them feel proud of your righteous leadership. Encouraged by your unmatched abilities as a ruler, they believed it would be appropriate to offer you a daily tribute for the duration of the Holidays.</p>
                         <p><b>Event Theme</b>: Snowballs. They will accumulate at a rate of 1 per minute, up to a maximum of 480 (8 hours). Collecting Snowballs will allow you to complete quests and increase your Avalanche upgrade bonus.</p>
                         <p>Every day, you will also receive a Christmas Present (image) containing Snowballs or Rubies. Presents are required to complete quests and can only be retrieved once per day by going online.</p>
-                        <p><b>Notes</b>: The daily Christmas presents contains 1 Ruby and 200 or 500 Snowballs</p>
+                        <p><b>Note</b>: The daily Christmas presents contains 1 Ruby and 200 or 500 Snowballs</p>
                         <p><b>Event Bonus</b>: Total cumulative and permanent quest bonus at the end of the Event: 14</p>
                         <p><b>Note</b>: If you didn't unlock all the Christmas feats last year, you have a chance to do so with this one! If you already did, you will be able to gain additional permanent production bonuses from completing all the quests again, and benefit from the massive bonus from the Avalanche upgrade once again.</p>
                         <p>You can find all this information in a guide by pressing the "?" button in the Event Panel.</p>

--- a/Factions/index.php
+++ b/Factions/index.php
@@ -35,7 +35,7 @@
 <p>Once unlocked they will stay unlocked throughout all Abdications and Reincarnations.</p>
 <p>To affiliate with a Faction, you first need to choose their Alignment.</p>
 <p>This makes all the Factions of that alignment available, and you can then choose which one to join.</p>
-<p><b>Notes</b>: Vanilla and Neutral Factions are together referred as <b>Base Factions</b>.</p>
+<p><b>Note</b>: Vanilla and Neutral Factions are together referred as <b>Base Factions</b>.</p>
 <p><b>Note</b>: The icons used in the below section are the Faction's <b>Trade Treaties</b>, their first Faction upgrade.</p>
 <hr>
 <p><b>Good Factions</b></p>
@@ -115,7 +115,7 @@
 <p><b><a href="/realm/DwarfFaction">Dwarf</a></b></p>
 <p><a href="/realm/DwarfFaction"><img src="http://musicfamily.org/realm/Factions/picks/DwarvenTradeTreaty.png"></a></p>
 <p><b>Alignment: Good</b></p>
-<p><b>Unlock Requirement</b>: Sturdy Bearded Man's Quest (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Sturdy Bearded Man's Quest (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Good Deed, Alliance upgrade of the Good Base Faction, Underworld Diplomacy (only R0-R2)</p>
 <p><b>Available</b>: R0-R99, R116-R219</p>
 <p><b>Cost</b> 3,000 Dwarven Coins</p>
@@ -123,7 +123,7 @@
 <p><b><a href="/realm/DrowFaction">Drow</a></b></p>
 <p><a href="/realm/DrowFaction"><img src="http://musicfamily.org/realm/Factions/picks/DrowTradeTreatyFactionUpgrade.png"></a></p>
 <p><b>Alignment: Evil</b></p>
-<p><b>Unlock Requirement</b>: Cloaked Shady Figure's Quest (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Cloaked Shady Figure's Quest (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Evil Deed, Alliance upgrade of the Evil Base Faction, Underworld Diplomacy (only R0-R2)</p>
 <p><b>Available</b>: R0-R99, R116-R219</p>
 <p><b>Cost</b> 3,000 Drow Coins</p>
@@ -131,7 +131,7 @@
 <p><b><a href="/realm/DragonFaction">Dragon</a></b></p>
 <p><a href="/realm/DragonFaction"><img src="http://musicfamily.org/realm/Factions/picks/DragonsTradeTreatyFactionUpgrade.png"></a>
 <p><b>Alignment: Neutral</b></p>
-<p><b>Unlock Requirement</b>: Elder Dragon (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Elder Dragon (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Neutrality, Alliance upgrade of the Neutral Base Faction</p>
 <p><b>Available</b>: R46-R99, R116-R219</p>
 <p><b>Cost</b>: 5 B (5e9) Dwarven & Drow Coins</p>
@@ -142,7 +142,7 @@
 <p>Mercenaries were added in the After-life expansion as an ultimate powerhouse.</p>
 <p>Combines the spells and upgrades from other factions to create custom cross-faction <a href="http://musicfamily.org/realm/MercBuilds"><b>mercenary builds</b></a>.</p>
 <p><b>Unlock Requirement R3+</b>: Mercenary Tribute (only needs to be bought once)</p>
-<p><b>Unlock Requirement R160+</b>: Mercenary Duel (only needs to be bought once)</p> 
+<p><b>Unlock Requirement R160+</b>: Mercenary Duel (only needs to be bought once)</p>
 <p><b>Available</b>: R3-R99, R160-R219</p>
 <p><b>Cost</b> 50 Spd (5e55), A1+: Free</p>
 <hr>
@@ -151,7 +151,7 @@
 <p><a href="/realm/ArchonFaction"><img src="http://musicfamily.org/realm/Factions/picks/ArchonTradeTreaty.png"></a>
 <p><b>Alignment: Order</b></p>
 <p>Increase your ability to boost your production immensely over long periods of time.</p>
-<p><b>Unlock Requirement</b>: Archon Quest (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Archon Quest (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Order, Union upgrades of both Base & Prestige Faction</p>
 <p><b>Available</b>: R125-R219</p>
 <p><b>Cost</b>: 1 Oc (1e27) Angel & Undead Coins</p>
@@ -160,7 +160,7 @@
 <p><a href="/realm/DjinnFaction"><img src="http://musicfamily.org/realm/Factions/picks/DjinnTradeTreaty.png"></a></p>
 <p><b>Alignment: Chaos</b></p>
 <p>Granting you the ability to manipulate random outcomes to your advantage.</p>
-<p><b>Unlock Requirement</b>: Djinn Quest (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Djinn Quest (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Chaos, Union upgrades of both Base & Prestige Faction</p>
 <p><b>Available</b>: R125-R219</p>
 <p><b>Cost</b>: 1 Oc (1e27) Fairy & Demon Coins</p>
@@ -169,7 +169,7 @@
 <p><a href="/realm/MakersFaction"><img src="http://musicfamily.org/realm/Factions/picks/MakersTradeTreaty.png"></a></p>
 <p><b>Alignment: Balance</b></p>
 <p>Increase your ability to dominate all your resources.</p>
-<p><b>Unlock Requirement</b>: Makers Quest (only needs to be bought once)</p> 
+<p><b>Unlock Requirement</b>: Makers Quest (only needs to be bought once)</p>
 <p><b>Requirement</b>: Proof of Balance, Union upgrades of both Base & Prestige Faction</p>
 <p><b>Available</b>: R125-R219</p>
 <p><b>Cost</b>: 1 Oc (1e27) Elven & Goblin Coins</p>

--- a/R100Plus/index.php
+++ b/R100Plus/index.php
@@ -201,7 +201,7 @@
                 <p>E50,E1325,</p>
                 <p>A30,A120,</p>
                 <p>W1375</p>
-                <p><b>Notes</b>: Estimated time of 2 minutes to unlock.</p>
+                <p><b>Note</b>: Estimated time of 2 minutes to unlock.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -223,7 +223,7 @@
                 <p>E25,E320,</p>
                 <p>A3400,</p>
                 <p>W10,W1375</p>
-                <p><b>Notes</b>: Estimated time of 1 hour to unlock.</p>
+                <p><b>Note</b>: Estimated time of 1 hour to unlock.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -245,8 +245,8 @@
                 <p>E1325,</p>
                 <p>A50,A400,</p>
                 <p>W225,W1375</p>
-                <p><b>Notes</b>: Get 400 Royal Exchanges for Druid Lineage, then cast all spells for unlock.</p>
-                <p><b>Notes</b>: Estimated time of ? to unlock (instant with Planetary Force and Angel set).</p>
+                <p><b>Note</b>: Get 400 Royal Exchanges for Druid Lineage, then cast all spells for unlock.</p>
+                <p><b>Note</b>: Estimated time of ? to unlock (instant with Planetary Force and Angel set).</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -268,7 +268,7 @@
                 <p>E1,E145,E225,</p>
                 <p>A10,A400,</p>
                 <p>W25,W1375</p>
-                <p><b>Notes</b>: Estimated time of almost instant.</p>
+                <p><b>Note</b>: Estimated time of almost instant.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -290,8 +290,8 @@
                 <p>E10,E3250,</p>
                 <p>A1,A175,A3400,</p>
                 <p>W50,W205</p>
-                <p><b>Notes</b>: Requires T7 spells to get enough offline bonus for unlock.</p>
-                <p><b>Notes</b>: Estimated time of ? to unlock.</p>
+                <p><b>Note</b>: Requires T7 spells to get enough offline bonus for unlock.</p>
+                <p><b>Note</b>: Estimated time of ? to unlock.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -313,7 +313,7 @@
                 <p>E230,E1325,</p>
                 <p>A25,A270,</p>
                 <p>W1,W175,W1275</p>
-                <p><b>Notes</b>: Almost instant after buying research and buildings.</p>
+                <p><b>Note</b>: Almost instant after buying research and buildings.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -335,7 +335,7 @@
                 <p>E275,E1325,</p>
                 <p>A3400,</p>
                 <p>W260,W1375</p>
-                <p><b>Notes</b>: Estimated time of 5 minutes to unlock.</p>
+                <p><b>Note</b>: Estimated time of 5 minutes to unlock.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -357,7 +357,7 @@
                 <p>E135,E260,</p>
                 <p>A251,A375,A400,</p>
                 <p>W350,W1375</p>
-                <p><b>Notes</b>: Estimated 30 minutes to unlock.</p>
+                <p><b>Note</b>: Estimated 30 minutes to unlock.</p>
             </div>
         </div>
     </div>

--- a/R116Plus/index.php
+++ b/R116Plus/index.php
@@ -72,7 +72,7 @@
                 <p>E25,E145,E410,</p>
                 <p>A250,A495,</p>
                 <p>W10,W400,W560</p>
-                <p><b>Notes</b>: Swap S400 for S3200 when you can afford DN11.</p>
+                <p><b>Note</b>: Swap S400 for S3200 when you can afford DN11.</p>
             </div>
         </div>
 		<div class="shelementwhole">
@@ -94,7 +94,7 @@
                 <p>E400,E410,</p>
                 <p>A50,A120,A495,</p>
                 <p>W225,W400,W560</p>
-                <p><b>Notes</b>: Takes estimated 10 to 30 minutes to buy Spiritual Surge 7.</p>
+                <p><b>Note</b>: Takes estimated 10 to 30 minutes to buy Spiritual Surge 7.</p>
             </div>
         </div>
 		<br />
@@ -142,7 +142,7 @@
 				<p>E25,E410,E3250,</p>
 				<p>A495,A3400,</p>
 				<p>W10,W560,W1375</p>
-				<p><b>Notes</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
+				<p><b>Note</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -164,7 +164,7 @@
                 <p>E400,E410,</p>
                 <p>A50,A120,A495,</p>
                 <p>W225,W400,W560</p>
-                <p><b>Notes</b>: Takes estimated 10 to 30 minutes to buy Spiritual Surge 7.</p>
+                <p><b>Note</b>: Takes estimated 10 to 30 minutes to buy Spiritual Surge 7.</p>
             </div>
         </div>
     </div>
@@ -214,7 +214,7 @@
                 <p>E320,E350,E1225,</p>
                 <p>A300,A1200,A3400,</p>
                 <p>W275,W1375,W1400</p>
-                <p><b>Notes</b>: Swap E320 with E290 if you need more excavations.</p>
+                <p><b>Note</b>: Swap E320 with E290 if you need more excavations.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -235,7 +235,7 @@
                 <p>E135,E410</p>
                 <p>A50,A120,A495,</p>
                 <p>W225,W560,W1375</p>
-                <p><b>Notes</b>: Can reach 7e9 (7 B) - 1e10 (10 B) mana regen.</p>
+                <p><b>Note</b>: Can reach 7e9 (7 B) - 1e10 (10 B) mana regen.</p>
             </div>
         </div>
     </div>
@@ -280,8 +280,8 @@
                 <p>E10,E400,E495,</p>
                 <p>A1,A175,A410,A590,A3400,</p>
                 <p>W50,W205,W405,W520</p>
-				<p><b>Notes</b>: Cast only Tax Collection until you get Dragon lineage.</p>
-				<p><b>Notes</b>: Run the build until 15 minutes after DW12 is bought at minimum.</p>
+				<p><b>Note</b>: Cast only Tax Collection until you get Dragon lineage.</p>
+				<p><b>Note</b>: Run the build until 15 minutes after DW12 is bought at minimum.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -322,7 +322,7 @@
                 <p>E135,E410,</p>
                 <p>A50,A120,A495,</p>
                 <p>W225,W400,W560</p>
-				<p><b>Notes</b>: Estimated Time to Primal Balance +10 is ?.</p>
+				<p><b>Note</b>: Estimated Time to Primal Balance +10 is ?.</p>
             </div>
         </div>
     </div>
@@ -352,8 +352,8 @@
                 <p>E145,E350,E1225,</p>
                 <p>A300,A1200,A3400,</p>
                 <p>W275,W1375,W1400</p>
-                <p><b>Notes</b>: Buffing W275 is highly recommended.</p>
-                <p><b>Notes</b>: Leveling Undead to L30 first is fastest (Estimated time 3-5 hours).</p>
+                <p><b>Note</b>: Buffing W275 is highly recommended.</p>
+                <p><b>Note</b>: Leveling Undead to L30 first is fastest (Estimated time 3-5 hours).</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -381,7 +381,7 @@
                 <p>E25,E320,E410,</p>
                 <p>A495,A3400,</p>
                 <p>W10,W560,W1375</p>
-				<p><b>Notes</b>: For Faceless Lineage, Swap D150 with D3350, and Elf set with Faceless set.</p>
+				<p><b>Note</b>: For Faceless Lineage, Swap D150 with D3350, and Elf set with Faceless set.</p>
             </div>
         </div>
     </div>

--- a/R125Plus/index.php
+++ b/R125Plus/index.php
@@ -54,7 +54,7 @@
 				<p>E25,E410,E3250,</p>
 				<p>A495,A3400,</p>
 				<p>W10,W560,W1375</p>
-				<p><b>Notes</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
+				<p><b>Note</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -81,8 +81,8 @@
 				<p>E145,E410,</p>
 				<p>A50,A250,A495,</p>
 				<p>W225,W400,W560</p>
-				<p><b>Notes</b>: Takes estimated time of 15-25 minutes to buy Spiritual Surge 7 and set up the build at first few runs of an R.</p>
-				<p><b>Notes</b>: Swap E145 with E320 and C400 with C340 at 1e72 (1 Tvg) Gems or above.</p>
+				<p><b>Note</b>: Takes estimated time of 15-25 minutes to buy Spiritual Surge 7 and set up the build at first few runs of an R.</p>
+				<p><b>Note</b>: Swap E145 with E320 and C400 with C340 at 1e72 (1 Tvg) Gems or above.</p>
 			</div>
 		</div>
 	</div>
@@ -378,7 +378,7 @@
 				<p>E25,E410,E3250,</p>
 				<p>A495,A3400,</p>
 				<p>W10,W560,W1375</p>
-				<p><b>Notes</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
+				<p><b>Note</b>: Swap A3400 with A250 and E3250 with E145 at 1e50 (100 Qid) Gems+.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -400,8 +400,8 @@
 				<p>A50,A400,A495,</p>
 				<p>W225,W560,W1375</p>
 				<p><b>After Archon treaty</b>: S305,C340,D1375,E135,A250,W400 (Reimport build)</p>
-				<p><b>Notes</b>: Recommended buffing Excavations/Excavation Resets.</p>
-				<p><b>Notes</b>: Build is not able to buy Archon Union.</p>
+				<p><b>Note</b>: Recommended buffing Excavations/Excavation Resets.</p>
+				<p><b>Note</b>: Build is not able to buy Archon Union.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -423,8 +423,8 @@
 				<p>A50,A400,A495,</p>
 				<p>W225,W400,W560</p>
 				<p><b>After Archon treaty</b>: S330,C340,D1375,E400,A120,W180 (Reimport build)</p>
-				<p><b>Notes</b>: Recommended buffing Elf set (2000%+) and Excavations/Excavation Resets.</p>
-				<p><b>Notes</b>: Build is oriented for production and is not meant to buy Archon Union.</p>
+				<p><b>Note</b>: Recommended buffing Elf set (2000%+) and Excavations/Excavation Resets.</p>
+				<p><b>Note</b>: Build is oriented for production and is not meant to buy Archon Union.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -446,8 +446,8 @@
 				<p>A50,A400,A495,</p>
 				<p>W225,W400,W560</p>
 				<p><b>After Archon treaty</b>: S330,C340,D1375,E400,A120,W1375 (Reimport build)</p>
-				<p><b>Notes</b>: Recommended buffing Excavations/Excavation Resets.</p>
-				<p><b>Notes</b>: Build is oriented around buying Archon Union.</p>
+				<p><b>Note</b>: Recommended buffing Excavations/Excavation Resets.</p>
+				<p><b>Note</b>: Build is oriented around buying Archon Union.</p>
 			</div>
 		</div>
 	</div>
@@ -472,7 +472,7 @@
                 <p>E135,E410,</p>
                 <p>A50,A120,A495,</p>
                 <p>W225,W400,W560</p>
-                <p><b>Notes</b>: Estimated Time to Primal Balance +10 is up to 15 minutes.</p>
+                <p><b>Note</b>: Estimated Time to Primal Balance +10 is up to 15 minutes.</p>
             </div>
         </div>
 	    <div class="shelementwhole">
@@ -518,7 +518,7 @@
 				<p>E50,E410,E460,</p>
 				<p>A30,A120,A495,</p>
 				<p>W560,W1375</p>
-				<p><b>Notes</b>: Replace S3200 with S400 if buffed (?).</p>
+				<p><b>Note</b>: Replace S3200 with S400 if buffed (?).</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -565,7 +565,7 @@
 				<p>E1,E225,E495,E590,E1325,</p>
 				<p>A10,A410,A3400,</p>
 				<p>W25,W205,W405,W520</p>
-				<p><b>Notes</b>: Swap D1375 with D290 at 1e73 (10 Tvg) Gems+.</p>
+				<p><b>Note</b>: Swap D1375 with D290 at 1e73 (10 Tvg) Gems+.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -586,7 +586,7 @@
 				<p>E1,E225,E495,E590,E1325,</p>
 				<p>A10,A410,A3400,</p>
 				<p>W25,W205,W405,W520</p>
-				<p><b>Notes</b>: While A400 grows better than A3400, running this build more than a few minutes is not recommended.</p>
+				<p><b>Note</b>: While A400 grows better than A3400, running this build more than a few minutes is not recommended.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -672,7 +672,7 @@
 				<p>E10,E495,E400,E290,</p>
 				<p>A1,A175,A410,A590,A400,A120,</p>
 				<p>W50,W405,W520,W205,W525</p>
-				<p><b>Notes</b>: Swap W525 with W180 at 1e88 (10 Ocvg) Gems+.</p>
+				<p><b>Note</b>: Swap W525 with W180 at 1e88 (10 Ocvg) Gems+.</p>
 			</div>
 		</div>
 	</div>
@@ -697,7 +697,7 @@
 				<p>E50,E400,E410,</p>
 				<p>A30,A400,A495,</p>
 				<p>W560,W1375</p>
-				<p><b>Notes</b>: Cycle Maelstrom to target inns and set the correct Fairy Union buff.</p>
+				<p><b>Note</b>: Cycle Maelstrom to target inns and set the correct Fairy Union buff.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -718,7 +718,7 @@
 				<p>E25,E145,E410,</p>
 				<p>A250,A495,</p>
 				<p>W10,W560,W1375</p>
-				<p><b>Notes</b>: Estimated time to unlock is 10 minutes.</p>
+				<p><b>Note</b>: Estimated time to unlock is 10 minutes.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -740,7 +740,7 @@
 				<p>A1,A175,A400,A410,A590,</p>
 				<p>W50,W205,W405,W520</p>
 				<p><b>After Archon Treaty</b>: S3200,C400,D3350,E400,A120,W1375 (Reimport Build)</p>
-				<p><b>Notes</b>: Estimated time to unlock is 4 hours.</p>
+				<p><b>Note</b>: Estimated time to unlock is 4 hours.</p>
 			</div>
 		</div>
 	</div>

--- a/R135Plus/index.php
+++ b/R135Plus/index.php
@@ -46,7 +46,7 @@
 				<p><b>Note</b>: Swap E3250 with E145 at e18 (1 Qi) Gems+.</p>
 				<p><b>Note</b>: Swap C400 with C340 at e36 (1 Ud) Gems+.</p>
 				<p><b>Note</b>: Also buffs Titan Challenge 4.</p>
-				<p><b>Note</b>: At R154+, swap A3400 with A400 at 1e45 (1 Qad) Gems+</p> 
+				<p><b>Note</b>: At R154+, swap A3400 with A400 at 1e45 (1 Qad) Gems+</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -209,7 +209,7 @@
 				<p>E230,E320,E495,</p>
 				<p>A25,A400,A410,</p>
 				<p>W1,W135,W175,W405,W520,W590</p>
-				<p><b>Note</b>: This build <b>requires</b> a buffed W175 to quickly afford Djinn Treaty, run the "Early W175" buff build once until you have enough Hellfire Blast casts.</p> 
+				<p><b>Note</b>: This build <b>requires</b> a buffed W175 to quickly afford Djinn Treaty, run the "Early W175" buff build once until you have enough Hellfire Blast casts.</p>
 				<p><b>Note</b>: Swap E320 with E135 once you already have 2e8 (200 M) Hellfire Blast casts this Reincarnation.</p>
 				<p><b>Note</b>: R154+, e140 (100 Qiqag) Gems+ & long runs - swap E320 with E400.</p>
 				<p><b>Note</b>: A quick Spell casts buff (Spell buff build for 5 to 10 minutes) is helpful, more is not essential.</p>
@@ -529,14 +529,14 @@
 						<p><b>Note</b>: <b>Only for long inactive run</b> (1 day and more from ARC4, CL and game time combined):</p>
 						<p>- Replace Bloodline with Faceless and swap W205 with W1375.</p>
 						<p>- select another set of researches once available - S305,C250,D3350,E145,A120,W525.</p>
-						
+
 					</div>
 				</div>
 				<div class="shelementwhole">
 					<p onclick="shohid($(this));"><b> <a href="#" onclick="return false;">Chaos Factions (Djinn Challenge 5)</a></b></p>
 					<div class="autohide">
 						<p><b>Range</b>: 1e70 (10 Dvg) Gems+</p>
-						<p><b>Notes</b>: Djinn Challenge 5 requires 88 casts of Fairy Chanting, Hellfire Blast, Brainwave, Maelstrom, Limited Wish and Catalyst.</p>
+						<p><b>Note</b>: Djinn Challenge 5 requires 88 casts of Fairy Chanting, Hellfire Blast, Brainwave, Maelstrom, Limited Wish and Catalyst.</p>
 						<p>Use Faceless to immediately get the Catalyst casts and Fairy to immediately get the Limited Wish casts.</p>
 						<p>Get the remaining spells with Reverse Autocasting or just wait.</p>
 					</div>
@@ -867,7 +867,7 @@
 				<p><b>Note</b>: Buff Excavation resets (50+).</p>
 				<p><b>Note</b>: Needs a few minutes to buy all Upgrades.</p>
 				<p><b>Note</b>: Build improves with access to Dragon Perk 5.</p>
-				<p><b>Note for R148+, DJC4</b>: Regular Angelline Demon runs (2 hours+) outperforms this build.</p> 
+				<p><b>Note for R148+, DJC4</b>: Regular Angelline Demon runs (2 hours+) outperforms this build.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">

--- a/R160Plus/index.php
+++ b/R160Plus/index.php
@@ -48,7 +48,7 @@
                 <p>A30,A120,A270,A305,A400,</p>
                 <p>W1375</p>
                 <p><b>Additional</b>: S215,S330,S150,D525,E410,A250,A150,W180,W120,W150</p>
-                <p><b>Notes</b>: Reimport build when Limited Wish hits Spell duration. Don't reset Fairy Chanting, instead export/import your save to update the Spell durations.</p>
+                <p><b>Note</b>: Reimport build when Limited Wish hits Spell duration. Don't reset Fairy Chanting, instead export/import your save to update the Spell durations.</p>
                 <p><i>Combo for maximum production</i>: Maelstrom on HoL with assistants or Faction Coins. Catalyst on Gem Grinder. Limited Wish on Spell duration. DJC4 on 888% maximum Mana</p>
             </div>
         </div>
@@ -73,7 +73,7 @@
                 <p>E3300,E135,E495,E230,</p>
                 <p>A2950,A30,A120,A270,A305,A545,A10,</p>
                 <p>W135,W205,W275,W400,W1275,W1375,W150,W25,W180,</p>
-                <p><b>Notes</b>: Get Archonline before importing Researches. Reimport frequently to unlock each Research as Archonline grows.</p>
+                <p><b>Note</b>: Get Archonline before importing Researches. Reimport frequently to unlock each Research as Archonline grows.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -99,7 +99,7 @@
                 <p>A1500,A2950,A30,A120,A410,A545,A10,A105,A150,A250,A270,A305,A375,A55,</p>
                 <p>W5125,W275,W400,W205,W25,W135,W150,W180,W250,W175,W120,</p>
                 <p>F5750</p>
-                <p><b>Notes</b>: Swap DN2->DM2, once you have 1h+ evil time this R.</p>
+                <p><b>Note</b>: Swap DN2->DM2, once you have 1h+ evil time this R.</p>
             </div>
         </div>
     </div>
@@ -129,7 +129,7 @@
                 <p>A30,A55,A105,A120,A135,A150,A175,A250,A270,A305,A375,A495,A545,A2950,</p>
                 <p>W25,W120,W135,W150,W175,W180,W250,W260,W275,W290,W330,W400,W590,W1275,W1375,</p>
                 <p>F5500</p>
-                <p><b>Notes</b>: Reset spells periodically, especially Fairy Chanting. Capable of 1e18 max mana/regeneration at e80 gems, requires buffing max Ziggurat count. Also allows TTC4 buffing.</p>
+                <p><b>Note</b>: Reset spells periodically, especially Fairy Chanting. Capable of 1e18 max mana/regeneration at e80 gems, requires buffing max Ziggurat count. Also allows TTC4 buffing.</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -177,7 +177,7 @@
                 <p>A2950,A270,A5375,</p>
                 <p>W275,W1275,W1375,W400,W180,</p>
                 <p>F6000,F5500</p>
-                <p><b>Notes</b>: After buying A5375, buy A120 and A545</p>
+                <p><b>Note</b>: After buying A5375, buy A120 and A545</p>
             </div>
         </div>
     </div>
@@ -205,7 +205,7 @@
                 <p>A30,A120,A270,A305,A545,A2950,A1500,</p>
                 <p>W275,W1275,W1375,W400,W1400,</p>
                 <p>F5250</p>
-                <p><b>Notes</b>: Elfline -> A2950:Maker/Druid(?). Dragonline/Makersline -> Replace Dragon Breath/Infinite Spiral with Lightning Strike. Buff assistants, max Flesh Workshops Excavations and resets.</p>
+                <p><b>Note</b>: Elfline -> A2950:Maker/Druid(?). Dragonline/Makersline -> Replace Dragon Breath/Infinite Spiral with Lightning Strike. Buff assistants, max Flesh Workshops Excavations and resets.</p>
             </div>
         </div>
     </div>
@@ -230,7 +230,7 @@
                 <p>E135,E145,E320,E1325,</p>
                 <p>A120,A270,A305,A400,A1325,</p>
                 <p>W400,W1375</p>
-                <p><b>Notes</b>: Buff excavations/resets for best results</p>
+                <p><b>Note</b>: Buff excavations/resets for best results</p>
             </div>
         </div>
         <div class="shelementwhole">
@@ -250,8 +250,8 @@
                 <p>E50,E135,E145,E320,E400,E460,E1325,</p>
                 <p>A30,A55,A105,A120,A150,A250,A270,A305,A400,A495,A545,</p>
                 <p>W135,W1275,W1375</p>
-                <p><b>Notes</b>: Run this build for ~5 hours after completing clicks requirement
-                <p><b>Notes</b>: Relies on Limited Wish:spell duration increasing DN9. Don't reset spells, but import/export to update duration.</p>
+                <p><b>Note</b>: Run this build for ~5 hours after completing clicks requirement
+                <p><b>Note</b>: Relies on Limited Wish:spell duration increasing DN9. Don't reset spells, but import/export to update duration.</p>
             </div>
         </div>
     </div>

--- a/R190Plus/index.php
+++ b/R190Plus/index.php
@@ -43,9 +43,9 @@
           <p>E290,E1225,E10,E320,E460,E480,E1325,E25,E30,E80,</p>
           <p>A1,A55,A105,A135,A150,A175,A375,A545,A495,A590,A480,A330,A300,</p>
           <p>W205,W25,W50</p>
-          <p><b>Notes</b>: Used to get a meaningful gem count before doing buff runs and switching to the main 190-198 production build.</p> 
-          <p><b>Notes</b>: Import the primary template repeatedly as you earn more points until all researches listed have been picked (usually W5625 is the last one to get selected), then repeatedly import secondary researches. Wait for Catalyst to hit Gem Grinder for maximum production before abdicating.</p> 
-          <p><b>Notes</b>: As with other builds, reset all spells periodically to increase their duration and buff effects, especially Fairy chanting and Precognition.</p>
+          <p><b>Note</b>: Used to get a meaningful gem count before doing buff runs and switching to the main 190-198 production build.</p>
+          <p><b>Note</b>: Import the primary template repeatedly as you earn more points until all researches listed have been picked (usually W5625 is the last one to get selected), then repeatedly import secondary researches. Wait for Catalyst to hit Gem Grinder for maximum production before abdicating.</p>
+          <p><b>Note</b>: As with other builds, reset all spells periodically to increase their duration and buff effects, especially Fairy chanting and Precognition.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -83,8 +83,8 @@
           <p>E1225,E320,E150,E200,E330,E350,E480,E145,E290,</p>
           <p>A305,A105,A150,A175,A250,</p>
           <p>W1375,W120,W150,W25,W180,</p>
-          <p><b>Notes</b>: Buff: max Ziggurats, max Flesh Workshops, TTC4, and optionally spells and assistants.</p>
-          <p><b>Notes</b>: Weaker than DPE, but requires no F6000 and can finish reincarnations up to R198 before DPE becomes usable.</p>
+          <p><b>Note</b>: Buff: max Ziggurats, max Flesh Workshops, TTC4, and optionally spells and assistants.</p>
+          <p><b>Note</b>: Weaker than DPE, but requires no F6000 and can finish reincarnations up to R198 before DPE becomes usable.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -128,11 +128,11 @@
           <p>D25,D150,D320,</p>
           <p>E290,E1225,E10,E320,E460,E480,E1325,</p>
           <p>W120,W150,W25,W180</p>
-          <p><b>Notes</b>: This build is the strongest found so far in R190-198, but is only functional if you have spent more than the usual amount of time in those Rs. Use this if you have been inactive in an R for a longer period.</p> 
-          <p><b>Notes</b>: Switch DN2->DM2 when going for A5375.</p> 
-          <p><b>Notes</b>: Buff F6000, Ziggurats (This R), Flesh Workshops (This R), Mana produced, Assistants.</p> 
-          <p><b>Notes</b>: Requires approximately 46.5 hours (This Game, including time from Chronos Loading, F6000, and DM4) to be able to afford A5375 (7-10h time this R depending on facless lineage level). Rs up to 198 can be finished by the previous build before DPE can afford A5375.</p>
-          <p><b>Notes</b>: This build requires recasting spells occasionally, especially Fairy Chanting and Precognition.</p>
+          <p><b>Note</b>: This build is the strongest found so far in R190-198, but is only functional if you have spent more than the usual amount of time in those Rs. Use this if you have been inactive in an R for a longer period.</p>
+          <p><b>Note</b>: Switch DN2->DM2 when going for A5375.</p>
+          <p><b>Note</b>: Buff F6000, Ziggurats (This R), Flesh Workshops (This R), Mana produced, Assistants.</p>
+          <p><b>Note</b>: Requires approximately 46.5 hours (This Game, including time from Chronos Loading, F6000, and DM4) to be able to afford A5375 (7-10h time this R depending on facless lineage level). Rs up to 198 can be finished by the previous build before DPE can afford A5375.</p>
+          <p><b>Note</b>: This build requires recasting spells occasionally, especially Fairy Chanting and Precognition.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -165,7 +165,7 @@
           <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
           <p>W25,W175,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Buff Fairyset (1-2h+), mana produced, max assistants, F6000, max Flesh Workshops, highest mana regeneration, excavations/excavation resets this R. At e80+, switch to Brothel. Reset spells often.</p>
+          <p><b>Note</b>: Buff Fairyset (1-2h+), mana produced, max assistants, F6000, max Flesh Workshops, highest mana regeneration, excavations/excavation resets this R. At e80+, switch to Brothel. Reset spells often.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -191,8 +191,8 @@
           <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
           <p>W180,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Swap e5125+e320->e5375 if the run is longer than 30 min.</p>
-          <p><b>Notes</b>: Buff: F6000, Fairy time (2-12+ hours, increasing each R), Max Flesh Workshops, Max Brothels, assistants, mana produced. Recast Fairy Chanting periodically. Remember to max Call to Arms tiers.</p>
+          <p><b>Note</b>: Swap e5125+e320->e5375 if the run is longer than 30 min.</p>
+          <p><b>Note</b>: Buff: F6000, Fairy time (2-12+ hours, increasing each R), Max Flesh Workshops, Max Brothels, assistants, mana produced. Recast Fairy Chanting periodically. Remember to max Call to Arms tiers.</p>
         </div>
       </div>
     </div>
@@ -218,7 +218,7 @@
           <p>A30,A55,A105,A120,A135,A150,A200,A250,A305,A330,A400,A480,A3400,</p>
           <p>W120,W135,W150,W180,W200,W250,W400,W1375,W3150,</p>
           <p>F6000</p>
-          <p><b>Notes</b>: Run at the beginning of each R from R198-R219. Run length increases each R, anywhere from 1 hour to 1 day. Run needs to be online.</p>
+          <p><b>Note</b>: Run at the beginning of each R from R198-R219. Run length increases each R, anywhere from 1 hour to 1 day. Run needs to be online.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -240,7 +240,7 @@
           <p>A30,A55,A105,A120,A135,A150,A200,A250,A270,A305,A330,A400,A480,A495,A545,A1325,</p>
           <p>W120,W135,W150,W180,W200,W250,W290,W320,W330,W400,W560,W1275,W1375,</p>
           <p>F5500</p>
-          <p><b>Notes</b>: Only needs to be run once in A3, preferably either in R206 after finishing 1 day each of evil/neutral/order/balance, or in R219. Increases combo strike count primarily through DJC1 and Drow challenge reward. <b>DO NOT</b> recast fairy chanting; instead, update its duration by exporting your save and reimporting it. This prevents the DJC1 effect from being reset. Benefits from buffing s5375 and d5625. Recommended value to aim for is ~300%</p>
+          <p><b>Note</b>: Only needs to be run once in A3, preferably either in R206 after finishing 1 day each of evil/neutral/order/balance, or in R219. Increases combo strike count primarily through DJC1 and Drow challenge reward. <b>DO NOT</b> recast fairy chanting; instead, update its duration by exporting your save and reimporting it. This prevents the DJC1 effect from being reset. Benefits from buffing s5375 and d5625. Recommended value to aim for is ~300%</p>
         </div>
       </div>
       <br/>
@@ -268,7 +268,7 @@
           <p>A5375,A270,A2950,A30,A120,</p>
           <p>W275,W400,W1275,W5625,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: Needs enough F6000 to afford all Alchemy researches. After buying the listed researches, fill in with other researches to maximize production and DJ3.</p>
+          <p><b>Note</b>: Needs enough F6000 to afford all Alchemy researches. After buying the listed researches, fill in with other researches to maximize production and DJ3.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -292,9 +292,9 @@
           <p>A120,A270,A2950,A5375,</p>
           <p>W275,W5625,W1275,W5125,</p>
           <p>F5250,F5500</p>
-          <p><b>Notes</b>: Use additional points for DJ3 buff</p>
-          <p><b>Notes</b>: Needs 2d F6000 and 1d evil time to afford all researches. Needs DWP1 buffed (tested at 300%).</p>
-          <p><b>Notes</b>: Should be able to reach up to 1e26 Max mana</p>
+          <p><b>Note</b>: Use additional points for DJ3 buff</p>
+          <p><b>Note</b>: Needs 2d F6000 and 1d evil time to afford all researches. Needs DWP1 buffed (tested at 300%).</p>
+          <p><b>Note</b>: Should be able to reach up to 1e26 Max mana</p>
         </div>
       </div>
       <br/>
@@ -321,7 +321,7 @@
           <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
           <p>W25,W175,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Buff max assistants, mana produced, F6000</p>
+          <p><b>Note</b>: Buff max assistants, mana produced, F6000</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -368,8 +368,8 @@
           <p>A30,A55,A105,A120,A270,A305,A545,A1500,A2950,</p>
           <p>W180,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Buff F6000, max assistants</p>
-          <p><b>Notes</b>: At coin cap: DJ7->DJ9, DJ3->DM2, S researches->S5875?, F5750->F5250 if you have offline time. If you can still reach cap: Grand balance-> moon blessing</p>
+          <p><b>Note</b>: Buff F6000, max assistants</p>
+          <p><b>Note</b>: At coin cap: DJ7->DJ9, DJ3->DM2, S researches->S5875?, F5750->F5250 if you have offline time. If you can still reach cap: Grand balance-> moon blessing</p>
         </div>
       </div>
       <br/>
@@ -401,8 +401,8 @@
           <p>A2950,A270,A5375,</p>
           <p>W1275,W275,W5125,W400,W1375,</p>
           <p>F6000,F5500</p>
-          <p><b>Notes</b>: For multiple day F6000, buffing DM2 is recommended. Secondary researches to spend extra points on: S400,S2875,S180,C5125,C250,A120,A305,A3400,W3050</p>
-          <p><b>Notes</b>: Buy E3300 only when you're ready to abdicate. E3300 tanks the production of the build but massively boosts F6000. Buy any buildings that E3300 provides with the building cost reduction, refresh all spells and then abdicate.</p>
+          <p><b>Note</b>: For multiple day F6000, buffing DM2 is recommended. Secondary researches to spend extra points on: S400,S2875,S180,C5125,C250,A120,A305,A3400,W3050</p>
+          <p><b>Note</b>: Buy E3300 only when you're ready to abdicate. E3300 tanks the production of the build but massively boosts F6000. Buy any buildings that E3300 provides with the building cost reduction, refresh all spells and then abdicate.</p>
         </div>
       </div>
       <br/>
@@ -428,8 +428,8 @@
           <p>A2950,A270,A5375,</p>
           <p>W5625,W1275,W275,W400,W1375,W205,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: After A5375: A30,A120,A305,A250,A1500</p>
-          <p><b>Notes</b>: Recommended F6000 10h to buy A5375</p>
+          <p><b>Note</b>: After A5375: A30,A120,A305,A250,A1500</p>
+          <p><b>Note</b>: Recommended F6000 10h to buy A5375</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -454,8 +454,8 @@
           <p>A30,A120,A270,A305,A2950,A3400,</p>
           <p>W205,W275,W400,W1275,W5625,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: Maelstrom should target Hall of Legends on assistants. When Chaos Madness hits Faceless, export/import to reset durations. Wait until Chaos Madness hits Dragon for maximum assistants. Buff: spells cast, max Flesh Workshops, evil time this R.</p>
-          <p><b>Notes</b>: Save excavation resets during the R to use as many as possible during the run.</p>
+          <p><b>Note</b>: Maelstrom should target Hall of Legends on assistants. When Chaos Madness hits Faceless, export/import to reset durations. Wait until Chaos Madness hits Dragon for maximum assistants. Buff: spells cast, max Flesh Workshops, evil time this R.</p>
+          <p><b>Note</b>: Save excavation resets during the R to use as many as possible during the run.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -480,8 +480,8 @@
           <p>A30,A55,A105,A250,A270,A305,A410,A1500,A2950,</p>
           <p>W1,W25,W275,W5625,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: Run this build repeatedly after running the Dwarfline build to achieve highest assistant count.</p>
-          <p><b>Notes</b>: Maelstrom should target Hall of Legends on assistants. When Chaos Madness hits Faceless, export/import to reset durations. Wait until Chaos Madness hits Dragon for maximum assistants.</p>
+          <p><b>Note</b>: Run this build repeatedly after running the Dwarfline build to achieve highest assistant count.</p>
+          <p><b>Note</b>: Maelstrom should target Hall of Legends on assistants. When Chaos Madness hits Faceless, export/import to reset durations. Wait until Chaos Madness hits Dragon for maximum assistants.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -506,7 +506,7 @@
           <p>A30,A120,A270,A305,A545,A1500,A2950,A250,</p>
           <p>W180,W275,W400,W1275,W1375,W150,W175,W200,W250,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: Run multiple times to buff assistants more. Buff F6000 and mana produced. Recast Fairy Chanting often.</p>
+          <p><b>Note</b>: Run multiple times to buff assistants more. Buff F6000 and mana produced. Recast Fairy Chanting often.</p>
         </div>
       </div>
       <br/>
@@ -531,7 +531,7 @@
           <p>A5375,A270,A2950,A30,A120,A545,</p>
           <p>W1275,W5625,W275,W400,W1375,W205,</p>
           <p>F5250</p>
-          <p><b>Notes</b>: Requires ? F6000 (less than 6 hours). Buff FR12 (Titanline Fairy or Faceline Fairy (recommend for like 202-206)) and Mana produced, let grow until Catalyst hits Gem Grinder for maximum gains.</p>
+          <p><b>Note</b>: Requires ? F6000 (less than 6 hours). Buff FR12 (Titanline Fairy or Faceline Fairy (recommend for like 202-206)) and Mana produced, let grow until Catalyst hits Gem Grinder for maximum gains.</p>
         </div>
       </div>
       <br/>
@@ -557,8 +557,8 @@
           <p>A120,A250,A270,A305,A545,A1500,A2950,</p>
           <p>W175,W180,W275,W400,W1275,W1375,W1400,</p>
           <p>F5500</p>
-          <p><b>Notes</b>: Buff: max assistants, excavations/excavation resets, max labyrinths, spells cast, F6000. At ? F6000, substitute A3400 for A545</p>
-          <p><b>Notes</b>: Estimated time to completion ? hours.</p>
+          <p><b>Note</b>: Buff: max assistants, excavations/excavation resets, max labyrinths, spells cast, F6000. At ? F6000, substitute A3400 for A545</p>
+          <p><b>Note</b>: Estimated time to completion ? hours.</p>
         </div>
       </div>
       <br/>
@@ -589,7 +589,7 @@
           <p>A30,A105,A120,A150,A270,A305,A545,A1500,A2950,</p>
           <p>W180,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: For buffing brothels switch Flesh Workshop->Brothel and AN4->FR4</p>
+          <p><b>Note</b>: For buffing brothels switch Flesh Workshop->Brothel and AN4->FR4</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -614,7 +614,7 @@
           <p>A30,A55,A105,A120,A135,A175,A250,A270,A305,A1500,A2950,</p>
           <p>W180,W275,W400,W5125,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Functions similarly to Benevolent Warchant. Recast spells periodically. Can substitute Mountain Palace for other unique buildings to buff their count after an initial run.</p>
+          <p><b>Note</b>: Functions similarly to Benevolent Warchant. Recast spells periodically. Can substitute Mountain Palace for other unique buildings to buff their count after an initial run.</p>
         </div>
       </div>
     </div>
@@ -643,9 +643,9 @@
           <p>A250,A120,A270,A305,A1500,A2950,</p>
           <p>W1275,W1375,W1400,W275,W400,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: First level druidline to 72/73, then bring elfline up to par, then run druid for the highest level.</p>
-          <p><b>Notes</b>: Recast spells during Chaos Madness: Faceless for maximum duration to increase druid advanced heritage. Fill in with other researches for additional production for additional buildings.</p>
-          <p><b>Notes</b>: Recommended minimum buffs: 1hr minimum spell activity time, 1e6 excavations, 30 excavation resets, Flesh Workshops, 1e30 max assistants, 8hr evil time, 11hr F6000, 11hr Future Linkin, 1e92 gems, and Elf lineage</p>
+          <p><b>Note</b>: First level druidline to 72/73, then bring elfline up to par, then run druid for the highest level.</p>
+          <p><b>Note</b>: Recast spells during Chaos Madness: Faceless for maximum duration to increase druid advanced heritage. Fill in with other researches for additional production for additional buildings.</p>
+          <p><b>Note</b>: Recommended minimum buffs: 1hr minimum spell activity time, 1e6 excavations, 30 excavation resets, Flesh Workshops, 1e30 max assistants, 8hr evil time, 11hr F6000, 11hr Future Linkin, 1e92 gems, and Elf lineage</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -670,7 +670,7 @@
           <p>A270,A305,A1500,A2950,A55,A105,A120,A135,A150,A250,</p>
           <p>W275,W400,W1275,W1375,W1400,W25,W120,W135,W150,W175,W180,W200,W250,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Notes: If using Dragon/Makers lineage, swap in Lightning Strike as the remaining spell. Reset all your spells and reactivate them during Chaos Madness: Faceless, then most progress will be made during Chaos Madness: Archon or Chaos Madness: Titan. If you're doing titan, get Lightning Strike to hit Hall of Legends when you recast.</p>
+          <p><b>Note</b>: If using Dragon/Makers lineage, swap in Lightning Strike as the remaining spell. Reset all your spells and reactivate them during Chaos Madness: Faceless, then most progress will be made during Chaos Madness: Archon or Chaos Madness: Titan. If you're doing titan, get Lightning Strike to hit Hall of Legends when you recast.</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -694,9 +694,9 @@
           <p>A120,A270,A305,A545,A1500,A2950,</p>
           <p>W275,W400,W1275,W1375,W180,</p>
           <p>F5500</p>
-          <p><b>Notes</b>: Replace Titan Union with Drow Union if F6000 is less than ~80 hours. Buff AR8 (use DN9 if not using Druid lineage). Optimized for R206+, but can still quickly produce 75+ lineages with Mercenary Challenge 3 and no F6000. Level Druid lineage first.</p>
-          <p><b>Notes</b>: Buff: F6000, Future Linkin, Fairy time, spells cast, max assistants, clicks, excavations/excavation resets, max. Mountain Palaces, max Flesh Workshops, max Labyrinths.</p>
-          <p><b>Notes</b>: Dragon Lineage: Dragon's Breath -> Fairy Chanting, Maker Lineage: Elf A2950, Infinite Spiral -> Precognition
+          <p><b>Note</b>: Replace Titan Union with Drow Union if F6000 is less than ~80 hours. Buff AR8 (use DN9 if not using Druid lineage). Optimized for R206+, but can still quickly produce 75+ lineages with Mercenary Challenge 3 and no F6000. Level Druid lineage first.</p>
+          <p><b>Note</b>: Buff: F6000, Future Linkin, Fairy time, spells cast, max assistants, clicks, excavations/excavation resets, max. Mountain Palaces, max Flesh Workshops, max Labyrinths.</p>
+          <p><b>Note</b>: Dragon Lineage: Dragon's Breath -> Fairy Chanting, Maker Lineage: Elf A2950, Infinite Spiral -> Precognition
         </div>
       </div>
     </div>
@@ -724,8 +724,8 @@
           <p>A55,A120,A200,A250,A270,A305,A2950,A3400,</p>
           <p>W150,W205,W1275,W1375,W1400,W3150,</p>
           <p>F5750</p>
-          <p><b>Notes</b>: Works at e78 gems, possibly lower and Angel Lineage 66. Buff Flesh Workshops and Holy Sites. Buff F6000 to 3+ hours. Get A2950 and more expensive research first, fill in the rest to reach 50,000 research points spent as Archon allows you to. Max excavations/resets (this game) to buff C5625. Recast spells from time to time to extend their durations.</p>
-          <p><b>Notes</b>: <b>Do not buy Fairy/Elf/Goblin/Demon/Druid/Faceless/Makers/Djinn heritages/advanced heritages. Do not buy Chaos or Balance researches (i.e. C175, S180, W275, …)</b></p>
+          <p><b>Note</b>: Works at e78 gems, possibly lower and Angel Lineage 66. Buff Flesh Workshops and Holy Sites. Buff F6000 to 3+ hours. Get A2950 and more expensive research first, fill in the rest to reach 50,000 research points spent as Archon allows you to. Max excavations/resets (this game) to buff C5625. Recast spells from time to time to extend their durations.</p>
+          <p><b>Note</b>: <b>Do not buy Fairy/Elf/Goblin/Demon/Druid/Faceless/Makers/Djinn heritages/advanced heritages. Do not buy Chaos or Balance researches (i.e. C175, S180, W275, …)</b></p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -749,7 +749,7 @@
           <p>A25,A30,A55,A120,A135,A175,A270,A305,A375,A1500,A2950,</p>
           <p>W25,W135,W150,W175,W180,W250,W275,W290,W400,W1275,W1375,W1400,</p>
           <p>F5500</p>
-          <p><b>Notes</b>: Works at e70 gems and faceless lineage as low as 65. Reset brainwave and other spells to increment values tied to spell duration. Buff Ziggurats for DD10</p>
+          <p><b>Note</b>: Works at e70 gems and faceless lineage as low as 65. Reset brainwave and other spells to increment values tied to spell duration. Buff Ziggurats for DD10</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -775,12 +775,12 @@
           <p>A30,A120,A270,A2950,</p>
           <p>W400,W1275,</p>
           <p>F5500</p>
-          <p><b>Notes</b>: Cast everything bronze (except share benefits). Cast Share Benefits until you can buy all the upgrades. When ready to go, uncast everything and cast Share Benefits manually until faction chance goes to e12</p>
-          <p><b>Notes</b>: If you are missing Mana Regeneration: Add DD6 or/and cast Dragon Breath tier 5+</p>
-          <p><b>Notes</b>: If you are missing Max Mana : E1325 and DW6, get more Royal Exchanges, buff DJ3 (by buying small researches that don’t affect mana generation/faction find chance)</p>
-          <p><b>Notes</b>: If you are missing assistants : cast fairy chanting</p>
-          <p><b>Notes</b>: Might have have to remove some due to how buffed your run is, this was done without buffing anything (no spells, no assistants, no F6000, no excav reset)</p>
-          <p><b>Notes</b>: <b>Do not buy Art of the Crow upgrade</b></p>
+          <p><b>Note</b>: Cast everything bronze (except share benefits). Cast Share Benefits until you can buy all the upgrades. When ready to go, uncast everything and cast Share Benefits manually until faction chance goes to e12</p>
+          <p><b>Note</b>: If you are missing Mana Regeneration: Add DD6 or/and cast Dragon Breath tier 5+</p>
+          <p><b>Note</b>: If you are missing Max Mana : E1325 and DW6, get more Royal Exchanges, buff DJ3 (by buying small researches that don’t affect mana generation/faction find chance)</p>
+          <p><b>Note</b>: If you are missing assistants : cast fairy chanting</p>
+          <p><b>Note</b>: Might have have to remove some due to how buffed your run is, this was done without buffing anything (no spells, no assistants, no F6000, no excav reset)</p>
+          <p><b>Note</b>: <b>Do not buy Art of the Crow upgrade</b></p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -804,8 +804,8 @@
           <p>E135,E320,</p>
           <p>A2950,A305,</p>
           <p>W275,W400,W1375</p>
-          <p><b>Notes</b>: Buy A2950 before importing, don't buy: R power, challenge power, Holy Crusaders, UD heritage, FR and FC AH, Sun force, makers mask, Individual building upgrades (such as crop rotation for farms) except the Hall of Legends ones. Respec rubies before run if desired, otherwise, don't buy ruby power. Your 1 assistant comes from assistant squasher. Uncast dragon's breath and infinite spiral after getting enough FC.</p>
-          <p><b>Notes</b>: Buff excav resets, assistants</p>
+          <p><b>Note</b>: Buy A2950 before importing, don't buy: R power, challenge power, Holy Crusaders, UD heritage, FR and FC AH, Sun force, makers mask, Individual building upgrades (such as crop rotation for farms) except the Hall of Legends ones. Respec rubies before run if desired, otherwise, don't buy ruby power. Your 1 assistant comes from assistant squasher. Uncast dragon's breath and infinite spiral after getting enough FC.</p>
+          <p><b>Note</b>: Buff excav resets, assistants</p>
         </div>
       </div>
       <div class="shelementwhole">
@@ -825,8 +825,8 @@
               </p>
               <p>FR1,EL4,AN12,GB12,UD10,DM2,TT8,DD6,FC7,DN2,DW2,DW6,DG7,AR10,DJ7,MK5,</p>
               <p>SP:Fairy Chanting,SP:Infinite Spiral,UNN:DG,UNN:DW,</p>
-              <p><b>Notes</b>: Buff Excavation Resets, assistants to at least 1e32, and F6000.</p>
-              <p><b>Notes</b>: Should be able to buy enough buildings and exchanges shortly after buying all upgrades. Wait to buy Tyrant Garrison until after getting as many evil fortresses as possible.</p>
+              <p><b>Note</b>: Buff Excavation Resets, assistants to at least 1e32, and F6000.</p>
+              <p><b>Note</b>: Should be able to buy enough buildings and exchanges shortly after buying all upgrades. Wait to buy Tyrant Garrison until after getting as many evil fortresses as possible.</p>
             </div>
           </div>
           <div class="shelementwhole">
@@ -843,11 +843,11 @@
               </p>
               <p>FR4,EL7,AN12,GB12,UD10,DM9,TT8,DD6,FC3,DN2,DW2,DW6,DG4,AR10,DJ7,MK1,</p>
               <p>SP:Grand Balance,SP:Infinite Spiral,UNN:DN,UNN:TT</p>
-              <p><b>Notes</b>: Requires less stats than the standard build, but will likely be slower in normal circumstances due to chaos randomness. Use the standard build if you have e114+ gems and use this one if you have less.</p>
-              <p><b>Notes</b>: Don't buy freemason's hall; cycle maelstrom until the next cast will be targeting HoL with assistants and then stop casting; wait until chaos madness hits faceless lineage, and then re-enable autocasting on maelstrom and recast all other spells; let chaos madness hit elven lineage to gain FCs for royal exchanges; let chaos madness hit demon lineage for production to increase building count. Once inns are at around 65k, you may want to buy freemason's hall (and For Science! and Secret Exchange that it unlocks) to roughly double production and FC gain.</p>
-              <p><b>Notes</b>: Double buff F6000 and buff assistants/mana stats/excavation stats.</p>
+              <p><b>Note</b>: Requires less stats than the standard build, but will likely be slower in normal circumstances due to chaos randomness. Use the standard build if you have e114+ gems and use this one if you have less.</p>
+              <p><b>Note</b>: Don't buy freemason's hall; cycle maelstrom until the next cast will be targeting HoL with assistants and then stop casting; wait until chaos madness hits faceless lineage, and then re-enable autocasting on maelstrom and recast all other spells; let chaos madness hit elven lineage to gain FCs for royal exchanges; let chaos madness hit demon lineage for production to increase building count. Once inns are at around 65k, you may want to buy freemason's hall (and For Science! and Secret Exchange that it unlocks) to roughly double production and FC gain.</p>
+              <p><b>Note</b>: Double buff F6000 and buff assistants/mana stats/excavation stats.</p>
             </div>
-          </div>  
+          </div>
         </div>
       </div>
     </div>

--- a/R40-R46/index.php
+++ b/R40-R46/index.php
@@ -88,8 +88,8 @@
 					<p>E135,E145,E250,E260,E320,E480,</p>
 					<p>A120,A250,A305,A375,A400,A545,</p>
 					<p>W120,W135,W200,W250,W400</p>
-					<p><b>Notes</b>: Meant for unlocking Reversed and tiered autocast.</p>
-					<p><b>Notes</b>: Estimated time to unlock tiered Autocast is 30 minutes</p>
+					<p><b>Note</b>: Meant for unlocking Reversed and tiered autocast.</p>
+					<p><b>Note</b>: Estimated time to unlock tiered Autocast is 30 minutes</p>
 				</div>
 			</div>
 		</div>
@@ -157,9 +157,9 @@
 					<p>E145,E330,E400,E410,E480,</p>
 					<p>A105,A120,A150,A250,A270,</p>
 					<p>W120,W150,W180,W320,W400</p>
-					<p>Notes: Swap A150->A330 if higher</p>
-					<p><b>Notes</b>: Gets to 3750 assistants instantly without Sun Force Assistants, the hard part is the 1e70 (10 Dvg) coins cost.</p>
-					<p><b>Notes</b>: Estimated time to 1e70 (10 Dvg) coins: 45 minutes at 1e30 (1 No) Gems without spell tiers.</p>
+					<p><b>Note</b>: Swap A150->A330 if higher</p>
+					<p><b>Note</b>: Gets to 3750 assistants instantly without Sun Force Assistants, the hard part is the 1e70 (10 Dvg) coins cost.</p>
+					<p><b>Note</b>: Estimated time to 1e70 (10 Dvg) coins: 45 minutes at 1e30 (1 No) Gems without spell tiers.</p>
 				</div>
 			</div>
 			<br />

--- a/R47-R60/index.php
+++ b/R47-R60/index.php
@@ -76,13 +76,13 @@
 				<p>E145,E150,E200,E320,E330,</p>
 				<p>A105,A120,A250,A305,A400,</p>
 				<p>W150,W180,W260,W290,W320,W400</p>
-				<p><b>Notes</b>: R49+ swap E150->E460, E200->E1225.</p>
-				<p><b>Notes</b>: R50+ swap D55->D1275.</p>
-				<p><b>Notes</b>: R51+ swap C250->C1300, C500->C1325, A250->A270.</p>
-				<p><b>Notes</b>: R52+ swap D200->D1375, W320->W1375.</p>
-				<p><b>Notes</b>: R53+ swap E330->E1425</p>
-				<p><b>Notes</b>: R54+ swap S250->S1450.</p>
-				<p><b>Notes</b>: Time together Lightning Strike on Wyrm's den and Red Breath for maximal production.</p>
+				<p><b>Note</b>: R49+ swap E150->E460, E200->E1225.</p>
+				<p><b>Note</b>: R50+ swap D55->D1275.</p>
+				<p><b>Note</b>: R51+ swap C250->C1300, C500->C1325, A250->A270.</p>
+				<p><b>Note</b>: R52+ swap D200->D1375, W320->W1375.</p>
+				<p><b>Note</b>: R53+ swap E330->E1425</p>
+				<p><b>Note</b>: R54+ swap S250->S1450.</p>
+				<p><b>Note</b>: Time together Lightning Strike on Wyrm's den and Red Breath for maximal production.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -108,7 +108,7 @@
 				<p>E145,E320,E460,E1225,E1425,</p>
 				<p>A105,A120,A150,A305,A400,</p>
 				<p>W150,W180,W275,W400,W1375</p>
-				<p><b>Notes</b>: Swap S250->S305 if you have Tier 6 spells.</p>
+				<p><b>Note</b>: Swap S250->S305 if you have Tier 6 spells.</p>
 			</div>
 		</div>
 	</div>
@@ -153,8 +153,8 @@
 				<p>E135,E145,E250,E260,E1325,E1425,</p>
 				<p>A120,A250,A305,A400,A545,A1325,</p>
 				<p>W135,W180,W250,W400,W1375</p>
-				<p><b>Notes</b>: Do <b>NOT</b> buy dragon treaty until you have met the mana generated requirement.</p>
-				<p><b>Notes</b>: Estimated time 12-14 hours to 1e10 (10 B) mana generated.</p>
+				<p><b>Note</b>: Do <b>NOT</b> buy dragon treaty until you have met the mana generated requirement.</p>
+				<p><b>Note</b>: Estimated time 12-14 hours to 1e10 (10 B) mana generated.</p>
 			</div>
 		</div>
 	</div>

--- a/R60-R75/index.php
+++ b/R60-R75/index.php
@@ -47,9 +47,9 @@
 				<p>E145,E320,E1225,E1325,E1425,</p>
 				<p>A105,A120,A270,A400,A545,</p>
 				<p>W150,W180,W275,W400,W1375</p>
-				<p><b>Notes</b>: Excavate for Titanline at low gems.</p>
-				<p><b>Notes</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
-				<p><b>Notes</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
+				<p><b>Note</b>: Excavating for Titanline at low gems can be slightly faster.</p>
+				<p><b>Note</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
+				<p><b>Note</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
 			</div>
 		</div>
 	</div>
@@ -93,7 +93,7 @@
 				<p>E290,E145,E1225,E1325,E1425,</p>
 				<p>A105,A120,A305,A400,A545,</p>
 				<p>W180,W275,W400,W1275,W1375</p>
-				<p><b>Notes</b>: After buying Dragon treaty excavate for the spell tiers.</p>
+				<p><b>Note</b>: After buying Dragon treaty excavate for the spell tiers.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -114,7 +114,7 @@
 				<p>E145,E290,E320,E1225,E1425,</p>
 				<p>A105,A120,A270,A305,A400,</p>
 				<p>W180,W275,W400,W1275,W1375</p>
-				<p><b>Notes</b>: Get Undeadline/Titanline to a high level (15-17) then abdicate and do their Lineage Perk 2 challenges.</p>
+				<p><b>Note</b>: Get Undeadline/Titanline to a high level (15-17) then abdicate and do their Lineage Perk 2 challenges.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -155,8 +155,8 @@
 				<p>E135,E145,E260,E290,E1225,E1425,</p>
 				<p>A120,A305,A400,A545,A1325,A1500,</p>
 				<p>W150,W180,W350,W400,W1375</p>
-				<p><b>Notes</b>: Do <b>NOT</b> buy dragon treaty until you have met the mana generated requirement.</p>
-				<p><b>Notes</b>: Takes estimated 6-7 hours for mana requirement. The hardest requirement is the 90k building requirement. Requires free excavations to excavate Spiritual Surge 6 and Dragon's Breath 5. Grand Balance tiers or amount of targets is irrelevant for this build.</p>
+				<p><b>Note</b>: Do <b>NOT</b> buy dragon treaty until you have met the mana generated requirement.</p>
+				<p><b>Note</b>: Takes estimated 6-7 hours for mana requirement. The hardest requirement is the 90k building requirement. Requires free excavations to excavate Spiritual Surge 6 and Dragon's Breath 5. Grand Balance tiers or amount of targets is irrelevant for this build.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -176,7 +176,7 @@
 				<p>E135,E145,E320,E1225,E1325,E1425,</p>
 				<p>A105,A120,A375,A400,A545,A1500,</p>
 				<p>W135,W180,W350,W400,W1375</p>
-				<p><b>Notes</b>: Excavate for Dragon's Breath 5 and abdicate shortly after.</p>
+				<p><b>Note</b>: Excavate for Dragon's Breath 5 and abdicate shortly after.</p>
 			</div>
 		</div>
 	</div>

--- a/R75Plus/index.php
+++ b/R75Plus/index.php
@@ -30,8 +30,8 @@
 				<p>E135,E145,E200,E320,E330,</p>
 				<p>A105,A250,A305,A330,A400,</p>
 				<p>W150,W180,W290,W320,W330,W400</p>
-				<p><b>Notes</b>: If Fairyline is below L20 keep using Druidline Dragtan Starter in the previous section.</p>
-				<p><b>Notes</b>: Excavate for the royal exchanges to buy the lineage.</p>
+				<p><b>Note</b>: If Fairyline is below L20 keep using Druidline Dragtan Starter in the previous section.</p>
+				<p><b>Note</b>: Excavate for the royal exchanges to buy the lineage.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -51,9 +51,9 @@
 				<p>E145,E320,E1225,E1325,E1425,</p>
 				<p>A105,A120,A270,A400,A545,</p>
 				<p>W150,W180,W275,W400,W1375</p>
-				<p><b>Notes</b>: Excavate for Titanline at low gems.</p>
-				<p><b>Notes</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
-				<p><b>Notes</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
+				<p><b>Note</b>: Excavating for Titanline at low gems can be slightly faster.</p>
+				<p><b>Note</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
+				<p><b>Note</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -74,7 +74,7 @@
 				<p>E135,E145,E150,E200,E320,E330,</p>
 				<p>A105,A120,A250,A305,A330,A400,</p>
 				<p>W150,W180,W250,W290,W320,W330,W400</p>
-				<p><b>Notes</b>: Excavate for the royal exchanges to buy the lineage.</p>
+				<p><b>Note</b>: Excavate for the royal exchanges to buy the lineage.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -94,9 +94,9 @@
 				<p>E145,E320,E350,E1225,E1325,E1425,</p>
 				<p>A105,A120,A270,A305,A400,A545,</p>
 				<p>W150,W180,W275,W290,W400,W1375</p>
-				<p><b>Notes</b>: Excavate for Titanline at low gems.</p>
-				<p><b>Notes</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
-				<p><b>Notes</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
+				<p><b>Note</b>: Excavating for Titanline at low gems can be slightly faster.</p>
+				<p><b>Note</b>: Excavate for spell tiers (up to Dragons Breath tier 5 and Spiritual Surge tier 5) after Dragon. At higher gems excavate for Spiritual Surge tier 6 (use free excavation reset before abdicating if excavation count too high to setup the next run).</p>
+				<p><b>Note</b>: Target Lighting Strike at Wyrm's den for maximum production.</p>
 			</div>
 		</div>
 	</div>
@@ -121,8 +121,8 @@
 				<p>E135,E145,E320,E1225,E1325,E1425,</p>
 				<p>A105,A120,A375,A400,A545,A1500,</p>
 				<p>W180,W250,W350,W400,W1375</p>
-				<p><b>Notes</b>: For buffing Titanline Faceless, making Merc entry easier.</p>
-				<p><b>Notes</b>: Excavate for Dragon's Breath T5 and abdicate shortly after.</p>
+				<p><b>Note</b>: For buffing Titanline Faceless, making Merc entry easier.</p>
+				<p><b>Note</b>: Excavate for Dragon's Breath T5 and abdicate shortly after.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -143,9 +143,9 @@
 				<p>E135,E320,E1225,E1325,E1425,</p>
 				<p>A105,A120,A305,A400,A545,</p>
 				<p>W135,W180,W250,W400,W1375</p>
-				<p><b>Notes</b>: Use if your FC3 is 123% or higher.</p>
-				<p><b>Notes</b>: For buffing Titanline Faceless, making Merc entry easier.</p>
-				<p><b>Notes</b>: Excavate for Dragon's Breath T5 and abdicate shortly after.</p>
+				<p><b>Note</b>: Use if your FC3 is 123% or higher.</p>
+				<p><b>Note</b>: For buffing Titanline Faceless, making Merc entry easier.</p>
+				<p><b>Note</b>: Excavate for Dragon's Breath T5 and abdicate shortly after.</p>
 			</div>
 		</div>
 	</div>
@@ -188,8 +188,8 @@
 				<p>E135,E320,E590,E1225,</p>
 				<p>A120,A270,A305,A1500,</p>
 				<p>W275,W400,W1275,W1375</p>
-				<p><b>Notes</b>: Buff W275 before running this build.</p>
-				<p><b>Notes</b>: Estimated 10 minutes for Secrets of the Warrior to unlock. Use Research template to get Fairy Lineage 25 afterwards.</p>
+				<p><b>Note</b>: Buff W275 before running this build.</p>
+				<p><b>Note</b>: Estimated 10 minutes for Secrets of the Warrior to unlock. Use Research template to get Fairy Lineage 25 afterwards.</p>
 				<p><b>Build has 3 stages:</b></p>
 				<p><b>1</b>: Gather faction coins for 400 Fairy Exchanges and buy Fairy Lineage (Cast Lightning Strike and Dragon's Breath on bronze, Tax Collection on gold).</p>
 				<p><b>2</b>: Buy Freemason's Hall (1e125 / 100 Qag), Appraisal Vantage (1e135 / 1 Qaqag) and cast all spells on bronze at the highest tier, Tax Collection/ Appraisal Vantage on gold.</p>
@@ -240,8 +240,8 @@
 				<p>E135,E320,E1225,E1425,</p>
 				<p>A30,A105,A175,A1500,</p>
 				<p>W150,W180,W275,W1375</p>
-				<p><b>Notes</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
-				<p><b>Notes</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
+				<p><b>Note</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
+				<p><b>Note</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -289,10 +289,10 @@
 				<p>E135,E320,E1225,E1425,</p>
 				<p>A30,A105,A1500,A2950,</p>
 				<p>W150,W180,W275,W1375</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
-				<p><b>Notes</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
-				<p><b>Notes</b>: Swap W275->W3150 for R79+.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
+				<p><b>Note</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
+				<p><b>Note</b>: Swap W275->W3150 for R79+.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -325,10 +325,10 @@
 				<p>E135,E1225,E1425,E3300,</p>
 				<p>A1200,A1500,A2950,A3400,</p>
 				<p>W150,W180,W400,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: A1200 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
-				<p><b>Notes</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: A1200 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: Swap GB1->FC3 and DW6->EL5 at 1e86 (100 Spvg) gems.</p>
+				<p><b>Note</b>: Swap Lightning Strike->God's Hand at 1e88 (10 Ocvg) gems if you have God's Hand T6.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -356,12 +356,12 @@
 				<p>E135,E1225,E3250,E3300,</p>
 				<p>A120,A410,A1500,A2950,</p>
 				<p>W400,W525,W3050,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: S50 and A410 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: DG9 requires Dragon's Breath spell (Dragon Perk 2 purchased) to become available.</p>
-				<p><b>Notes</b>: Tiering every spell the build uses to T6 is highly recommended.</p>
-				<p><b>Notes</b>: At higher gems buffing TTC4, DM2 and FC3 when build slows down is recommended.</p>
-				<p><b>Notes</b>: Swap Night Time->Grand Balance if you have Primal Balance +10.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: S50 and A410 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: DG9 requires Dragon's Breath spell (Dragon Perk 2 purchased) to become available.</p>
+				<p><b>Note</b>: Tiering every spell the build uses to T6 is highly recommended.</p>
+				<p><b>Note</b>: At higher gems buffing TTC4, DM2 and FC3 when build slows down is recommended.</p>
+				<p><b>Note</b>: Swap Night Time->Grand Balance if you have Primal Balance +10.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -385,10 +385,10 @@
 				<p>E135,E260,E1225,E1425,E3300,</p>
 				<p>A105,A1200,A1500,A2950,A3400,</p>
 				<p>W150,W180,W260,W400,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: E260, A1200 and W260 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: Excavate to set up the build.</p>
-				<p><b>Notes</b>: Start the build at 1e70 (10 Dvg) gems instead if you don't have God's Hand T6.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: E260, A1200 and W260 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: Excavate to set up the build.</p>
+				<p><b>Note</b>: Start the build at 1e70 (10 Dvg) gems instead if you don't have God's Hand T6.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -412,10 +412,10 @@
 				<p>E135,E230,E1225,E3250,E3300,</p>
 				<p>A120,A410,A590,A1500,A2950,</p>
 				<p>W205,W400,W525,W3050,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: S50 and A410 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: DG9 requires Dragon's Breath spell (Dragon Perk 2 purchased) to become available.</p>
-				<p><b>Notes</b>: Benefits greatly from buffing TTC4, DM2 and FC3.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: S50 and A410 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: DG9 requires Dragon's Breath spell (Dragon Perk 2 purchased) to become available.</p>
+				<p><b>Note</b>: Benefits greatly from buffing TTC4, DM2 and FC3.</p>
 			</div>
 		</div>
 	</div>
@@ -448,9 +448,9 @@
 				<p>E135,E1225,E3250,E3300,</p>
 				<p>A120,A305,A1500,A2950,</p>
 				<p>W1375,W1400,W3050,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: S50 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: Swap C3100->C400 if not unlocked.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: S50 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: Swap C3100->C400 if not unlocked.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -478,10 +478,10 @@
 				<p>E135,E1225,E3250,E3300,</p>
 				<p>A120,A1500,A2950,A3400,</p>
 				<p>W1375,W1400,W3050,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: Benefits from Holy Crusader growth and high Undead & Elf Lineage levels.</p>
-				<p><b>Notes</b>: Fairyline Neutral Merc has a naturally high assistant count, therefore automatically buffs W275 / Freemason Hall by itself. This build only performs slightly better than Neutral Merc.</p>
-				<p><b>Notes</b>: For R90+ add S305,C225,D25,E50,A545,W400.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: Benefits from Holy Crusader growth and high Undead & Elf Lineage levels.</p>
+				<p><b>Note</b>: Fairyline Neutral Merc has a naturally high assistant count, therefore automatically buffs W275 / Freemason Hall by itself. This build only performs slightly better than Neutral Merc.</p>
+				<p><b>Note</b>: For R90+ add S305,C225,D25,E50,A545,W400.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -509,10 +509,10 @@
 				<p>E135,E1225,E3250,E3300,</p>
 				<p>A120,A1500,A2950,A3400,</p>
 				<p>W400,W1375,W1400,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: Build is for generating enough mana for Primal Balance (Druid's challenge reward).</p>
-				<p><b>Notes</b>: Estimated 1 hour (R82-89) or 45 minutes (R90+) for Primal Balance +10.</p>
-				<p><b>Notes</b>: For R90+ add S215,C400,D1375,E320,A305,W275 and swap DG3->FC2 (Requires Veteran Figurine).</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: Build is for generating enough mana for Primal Balance (Druid's challenge reward).</p>
+				<p><b>Note</b>: Estimated 1 hour (R82-89) or 45 minutes (R90+) for Primal Balance +10.</p>
+				<p><b>Note</b>: For R90+ add S215,C400,D1375,E320,A305,W275 and swap DG3->FC2 (Requires Veteran Figurine).</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -535,10 +535,10 @@
 				<p>E135,E320,E1225,E3250,E3300,</p>
 				<p>A120,A305,A1500,A2950,A3400,</p>
 				<p>W400,W1375,W1400,W3050,W3150</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: S50 requires E3300 purchased to become available.</p>
-				<p><b>Notes</b>: Alternative option to Mana Breeder Reactor for R90+. Gets Primal Balance +10 much slower but instead spends more time casting Lightning Strike and being Evil, thus buffing TTC4, DM2 and FC3. Helps future Evil Merc runs greatly.</p>
-				<p><b>Notes</b>: Estimated 2-3 (?) hours for Primal Balance +10.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: S50 requires E3300 purchased to become available.</p>
+				<p><b>Note</b>: Alternative option to Mana Breeder Reactor for R90+. Gets Primal Balance +10 much slower but instead spends more time casting Lightning Strike and being Evil, thus buffing TTC4, DM2 and FC3. Helps future Evil Merc runs greatly.</p>
+				<p><b>Note</b>: Estimated 2-3 (?) hours for Primal Balance +10.</p>
 			</div>
 		</div>
 	</div>
@@ -570,8 +570,8 @@
 				<p>E135,E320,E590,E1225,</p>
 				<p>A120,A270,A305,A1500,</p>
 				<p>W275,W400,W1375,W1400</p>
-				<p><b>Notes</b>: Level Fairy Lineage up to at least L25 with We Shall Rise Again and get to R Gems first before running this build.</p>
-				<p><b>Notes</b>: If you're doing Dragon Lineage and already have Dragon Perk 2 unlocked, swap Dragon's Breath->God's Hand.</p>
+				<p><b>Note</b>: Level Fairy Lineage up to at least L25 with We Shall Rise Again and get to R Gems first before running this build.</p>
+				<p><b>Note</b>: If you're doing Dragon Lineage and already have Dragon Perk 2 unlocked, swap Dragon's Breath->God's Hand.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -595,7 +595,7 @@
 				<p>E135,E320,E1225,E3300,</p>
 				<p>A305,A1500,A2950,A3400,</p>
 				<p>W275,W400,W1375,W1400</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
 			</div>
 		</div>
 		<div class="shelementwhole">
@@ -624,9 +624,9 @@
 				<p>E320,E1225,E3250,E3300,</p>
 				<p>A305,A1500,A2950,A3400,</p>
 				<p>W275,W400,W1375,W1400</p>
-				<p><b>Notes</b>: Always select the same lineage as your Bloodline, not A2950.</p>
-				<p><b>Notes</b>: Level Fairy Lineage up to at least L30 first before running this build.</p>
-				<p><b>Notes</b>: For Dragon Lineage swap Dragon's Breath->God's Hand and pick A2950: Elf instead.</p>
+				<p><b>Note</b>: Always select the same lineage as your Bloodline, not A2950.</p>
+				<p><b>Note</b>: Level Fairy Lineage up to at least L30 first before running this build.</p>
+				<p><b>Note</b>: For Dragon Lineage swap Dragon's Breath->God's Hand and pick A2950: Elf instead.</p>
 			</div>
 		</div>
 	</div>

--- a/ResearchBuilds/index.php
+++ b/ResearchBuilds/index.php
@@ -16,7 +16,7 @@
             <div class="shelementwhole">
                 <p onclick="shohid($(this));"><b><a href="#" onclick="return false;"><font color="DarkRed">Notes for R16</font></a></b></p>
                 <div class="autohide">
-                    <p><b>Notes</b></p>
+                    <p><b>Note</b></p>
                     <p>There is a relevant guide on how to go through the unlocking of the researches needed to start using research builds. (<a target="_blank" href="http://musicfamily.org/realm/R16Guide/"><b>R16 Research Guide</b></a>)</p>
                     <p>IMPORTANT: Although you unlock all researches at the end of R16, you do not use research until R17. Keep using Mercenary to finish R16 </p>
                     <p>All factions were used and tested, Goblin proved to be the best in a reasonable amount of time.</p>

--- a/ResearchList/index.php
+++ b/ResearchList/index.php
@@ -139,7 +139,7 @@
 					<p><b>Cost</b>: 225.2 OcQig (2.252e179)</p>
 					<p><b>Effect</b>: Increase the production of all buildings by a fraction of your Offline Production Bonus.</p>
 					<p><b>Formula</b>: (2.5 * log10(1 + x) ^ 2.5)%, where x is your (pre-Ascension) offline production bonus as a multiplier.</p>
-					<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+					<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 					<hr>
 					<p><b>S330</b> - For All Factions</p>
 					<p><b>Research Name</b>: Reverberation</p>
@@ -625,7 +625,7 @@
 					<p><b>Cost</b>: 12.63 Dqag (1.263E130)</p>
 					<p><b>Effect</b>: Increase the production of all buildings based on your offline production bonus.</p>
 					<p><b>Formula</b>: (2.75 * log10(1 + x) ^ 2.75)%, where x is your offline production bonus multiplier.</p>
-					<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+					<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 					<hr>
 					<p><b>D50</b> - For Elf</p>
 					<p><b>Research Name</b>: Hallowing</p>
@@ -1635,7 +1635,7 @@
 					<p><b>Cost</b>: 103.7 QaSxg (1.037E197)</p>
 					<p><b>Effect</b>: Increase the production of Spider Sanctuaries based on offline Bonus</p>
 					<p><b>Formula</b>: (3.25 * log10(1 + x) ^ 3.25)%, where x is offline production bonus multiplier.</p>
-					<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+					<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 					<hr>
 					<p><b>W520</b> - For Drow</p>
 					<p><b>Research Name</b>: Stalking</p>

--- a/Researchtree/index.php
+++ b/Researchtree/index.php
@@ -350,7 +350,7 @@
 	<p><b>Cost</b>: 225.2 OcQig (2.252e179)</p>
 	<p><b>Effect</b>: Increase the production of all buildings by a fraction of your Offline Production Bonus.</p>
 	<p><b>Formula</b>: (2.5 * log10(1 + x) ^ 2.5)%, where x is your (pre-Ascension) offline production bonus as a multiplier.</p>
-	<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+	<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 	" coords="2,86,42,126" shape="rect">
         <area research="<p><b>S330</b> - For All Factions</p>
 	<p><b>Research Name</b>: Reverberation</p>
@@ -825,7 +825,7 @@
 	<p><b>Cost</b>: 12.63 Dqag (1.263e130)</p>
 	<p><b>Effect</b>: Increase the production of all buildings based on your offline production bonus.</p>
 	<p><b>Formula</b>: (2.75 * log10(1 + x) ^ 2.75)%, where x is your offline production bonus multiplier.</p>
-	<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+	<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 	" coords="170,422,210,462" shape="rect">
         <area research="<p><b>D50</b> - For Elf</p>
 	<p><b>Research Name</b>: Hallowing</p>
@@ -1821,7 +1821,7 @@
 	<p><b>Cost</b>: 103.7 QaSxg (1.037e197)</p>
 	<p><b>Effect</b>: Increase the production of Spider Sanctuaries based on offline Bonus.</p>
 	<p><b>Formula</b>: (3.25 * log10(1 + x) ^ 3.25)%, where x is offline production bonus multiplier.</p>
-	<p><b>Notes</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
+	<p><b>Note</b>: This research is treated as an A1 upgrade for A-nerf purposes.</p>
 	" coords="170,1136,210,1176" shape="rect">
         <area research="<p><b>W520</b> - For Drow</p>
 	<p><b>Research Name</b>: Stalking</p>

--- a/Spells/index.php
+++ b/Spells/index.php
@@ -1172,7 +1172,7 @@
 <p><b>Requirements</b>: R130+, Djinn Bloodline</p>
 <p><b>Effect</b>: Activates a random vanilla or base alignment spell at tier 7 for 60 seconds. This spell's duration cannot be modified.</p>
 <p><b>Note</b>: Can not access Holy Frenzy regardless of alignment.</p>
-<p><b>Notes</b></p>
+<p><b>Note</b>:</p>
 <p><b>1</b>. Choosing this Bloodline or having/buying A400 with Djinn gives you the vanilla spell upgrades that enable the challenge reward when bought.</p>
 <p><b>2</b>. Cannot cast a spell that is already available.</p>
 <p><b>3</b>. The Spell Pool is 8 for Neutral factions, 7 for Good/Evil (-1 faction and -1 alignment spell)</p>

--- a/counter/readme.htm
+++ b/counter/readme.htm
@@ -368,7 +368,7 @@ Let's say you are using style web1 by default, which has GIF file format images 
 src=&quot;http://www.domain.com/counter/gcount.php?page=PAGENAME<span class="dest">&amp;style=myblue&amp;ext=jpg</span>&quot;&gt;&lt;!--
 //--&gt;&lt;/script&gt;</pre>
 
-<p><b>NOTE:</b> All the styles that come with PHPGCount by default are GIF type!<br />&nbsp;</p>
+<p><b>Note</b>: All the styles that come with PHPGCount by default are GIF type!<br />&nbsp;</p>
 
 
 


### PR DESCRIPTION
I mostly did note cleanup but I did also clarify one note in Titanline Faceless builds as well:
 * Clarified excavation note for Titanline Faceless builds in A1.
 * Replaced all instances of "Notes" with "Note" for consistency and as it make more sense for singular notes.
 * Fixed some notes that weren't properly bold where needed.
 * Fixed inconsistent bolding of the colon in a few notes. (\<b>Note:\</b> became \<b>Note\</b>: like it is in most of the site)