### PR TITLE
Quick fix for uniformity formula on AllTrophies

### DIFF
--- a/AllTrophies/index.php
+++ b/AllTrophies/index.php
@@ -350,7 +350,7 @@
 					<p><b>Requirement</b>: A2+, Have no less than 3 days of playtime with at least 24 hours each Order, Chaos and Balance and have less than 1 minute of playtime between them. (This R)</p>
 					<p><b>Cost</b>: 100 Qid (1e50)</p>
 					<p><b>Effect</b>: Increases the production of all buildings based on time spent as least used alignment (this Reincarnation).</p>
-					<p><b>Formula</b>: (0.75 * x ^ 0.75)%, where x is the time spent with your least used alignment (primary or secondary) in seconds.</p>
+					<p><b>Formula</b>: (x ^ 0.75)%, where x is the time spent with your least used alignment (primary or secondary) in seconds.</p>
 					<hr>
 					<p><img src="http://musicfamily.org/realm/Factions/picks/ArtoftheCrowTrophy.png" align="middle"><b> Art of the Crow</b></p>
 					<p><b>Requirement</b>: Have any 6 complete Faction Artifact Sets.</p>


### PR DESCRIPTION
The correct uniformity formula is used for TrophyPage, but not for AllTrophies (I guess due to a buff or something?)
![image](https://user-images.githubusercontent.com/80460672/190876059-1cfa3720-6aac-4b76-bbe4-cde2f66c47b0.png)
The bonus in-game was stated to be 487%