### PR TITLE
Changed Stoic Resistance gem requirements

### DIFF
--- a/Abdication/index.php
+++ b/Abdication/index.php
@@ -37,7 +37,7 @@
 <br/>
 <p><img src="http://musicfamily.org/realm/Factions/picks/StoicResistanceSecretTrophy.png" alt="Stoic Resistance" align="middle"> <b>Stoic Resistance</b> (R30+)</p>
 <p><b>Requirement</b>: Reach an amount of Gems in your treasury equal to the requisite of the first Reincarnation without abdicating since the start of a new Reincarnation.</p>
-<p><b>Gems Needed</b>: A0 = 1 Oc (1e27), A1+ = 177.8 Qi (1.778e20)</p>
+<p><b>Gems Needed</b>: A0 = 1 Oc (1e27), A1 = 177.8 Qi (1.778e20), A2 = 1.540 Qa (1.540e15), A3 = 245.8 B (2.458e11), A4 = 349.1 M (3.491e8)</p>
 <p><b>Effect</b>: Increase base clicking reward by 1 T (1E12).</p>
 <p><b>Cost</b>: 10 gold</p>
 <?php include "../scripts/footer.html"; ?>


### PR DESCRIPTION
It previously listed A0 = 1 Oc (1e27), A1+ = 177.8 Qi (1.778e20). Updated to match the A2-A4 values found on the trophy page.